### PR TITLE
feat: aurora, s3 리소스 테스트

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,107 @@
+# Mapzip Terraform 프로젝트
+
+## 1. 개요
+
+이 프로젝트는 Mapzip 서비스의 인프라를 Terraform으로 관리하기 위한 코드베이스입니다. 모든 리소스는 모듈화하여 재사용성을 높이고, `terraform.workspace`를 사용해 개발(dev), 스테이징(stg), 운영(prod) 환경을 구분합니다.
+
+## 2. 프로젝트 구조
+
+```
+.
+├── README.md
+├── argocd
+│   └── ...
+└── terraform
+    ├── modules
+    │   ├── aurora  # Aurora (PostgreSQL) 모듈
+    │   │   ├── main.tf
+    │   │   ├── outputs.tf
+    │   │   └── variables.tf
+    │   └── s3      # S3 버킷 모듈
+    │       ├── main.tf
+    │       ├── outputs.tf
+    │       └── variables.tf
+    ├── backend.tf
+    ├── main.tf       # 루트 모듈 (모듈 호출)
+    ├── outputs.tf
+    ├── providers.tf
+    └── variables.tf
+```
+
+- **`main.tf`**: 각 모듈을 호출하여 전체 인프라를 구성합니다.
+- **`variables.tf`**: 전역적으로 사용되는 변수를 정의합니다. (VPC, Subnet ID 등)
+- **`outputs.tf`**: 생성된 리소스의 주요 정보를 출력합니다.
+- **`modules/`**: 각 리소스별 모듈이 위치합니다.
+  - **`aurora/`**: Aurora PostgreSQL 클러스터 모듈
+  - **`s3/`**: S3 버킷 모듈
+
+## 3. 공통 규칙
+
+### 네이밍 규칙
+
+모든 리소스의 이름은 `mapzip-{환경명}-{리소스명}` 형식을 따릅니다. 환경명은 `terraform.workspace`를 통해 동적으로 결정됩니다.
+
+```hcl
+locals {
+  common_prefix = "mapzip-${terraform.workspace}-"
+  common_tags = {
+    Environment = terraform.workspace
+    Project     = "mapzip"
+    ManagedBy   = "Terraform"
+  }
+}
+```
+
+### 태그 관리
+
+모든 리소스에는 `local.common_tags`에 정의된 공통 태그가 필수로 포함되어야 합니다.
+
+## 4. 사용법
+
+### 환경 초기화
+
+최초 실행 시 또는 새로운 환경(workspace)을 추가할 때 아래 명령어를 실행합니다.
+
+```bash
+terraform init
+terraform workspace new dev
+```
+
+### 계획 및 적용
+
+Terraform 코드를 변경한 후에는 항상 `plan`을 통해 변경 사항을 확인하고 `apply`로 적용합니다.
+
+```bash
+# dev 환경에 대한 변경 계획 확인
+terraform plan -var-file="dev.tfvars"
+
+# dev 환경에 변경 사항 적용
+terraform apply -var-file="dev.tfvars"
+```
+
+**참고**: `dev.tfvars` 파일에는 VPC ID, Subnet ID 등 환경별 변수를 정의해야 합니다. 이 파일은 `.gitignore`에 추가하여 형상 관리에 포함되지 않도록 주의해야 합니다.
+
+## 5. 모듈 상세 설명
+
+### Aurora 모듈 (`modules/aurora`)
+
+- **기능**: `aurora-postgresql` 엔진을 사용하는 DB 클러스터를 생성합니다.
+- **주요 변수**:
+  - `vpc_id`: DB가 위치할 VPC ID
+  - `private_subnet_ids`: DB 클러스터가 사용할 Private Subnet ID 목록
+  - `allowed_security_group_id`: DB 접근을 허용할 보안 그룹 ID
+- **참고**: DB 이름, 계정, 비밀번호는 임시값을 사용하며, 추후 `SecretsManager`와 연동될 예정입니다.
+
+### S3 모듈 (`modules/s3`)
+
+- **기능**: 다용도 S3 버킷을 생성합니다.
+- **주요 변수**:
+  - `bucket_name`: 생성할 버킷의 기본 이름 (prefix가 추가됨)
+  - `is_public`: 버킷의 Public 접근 허용 여부 (기본값: `false`)
+- **참고**: 현재 모든 버킷은 비공개(private)로 설정되며, 버전 관리는 비활성화되어 있습니다.
+
+## 6. TODO
+
+- [ ] `SecretsManager`를 연동하여 DB 계정 정보 관리
+- [ ] S3 버킷 Public 접근 정책 구체화
+- [ ] EKS 클러스터 구성 및 `depends_on` 설정

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,90 @@
+# 루트 모듈 (main.tf)
+
+# ------------------------------------------------------------------------------
+# 로컬 변수 정의
+# - 공통으로 사용될 이름 접두사(prefix)와 태그를 정의합니다.
+# - terraform.workspace를 사용하여 현재 작업 환경을 동적으로 참조합니다.
+# ------------------------------------------------------------------------------
+locals {
+  # 리소스 이름에 공통으로 사용할 접두사 (e.g., mapzip-dev-)
+  common_prefix = "mapzip-${terraform.workspace}-"
+
+  # 모든 리소스에 공통으로 적용할 태그
+  common_tags = {
+    Environment = terraform.workspace
+    Project     = "mapzip"
+    ManagedBy   = "Terraform"
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Aurora (PostgreSQL) 모듈 호출
+# - modules/aurora 디렉토리의 모듈을 사용하여 DB 클러스터를 생성합니다.
+# - 네트워크 정보 및 DB 계정 정보는 변수를 통해 주입합니다.
+# ------------------------------------------------------------------------------
+module "aurora_db" {
+  source = "./modules/aurora"
+
+  # --- 공통 변수 전달 ---
+  environment = terraform.workspace
+  common_tags = local.common_tags
+
+  # --- 네트워크 변수 전달 (외부에서 값 주입 필요) ---
+  vpc_id                      = var.vpc_id
+  private_subnet_ids          = var.private_subnet_ids
+  allowed_security_group_id   = var.db_security_group_id
+  availability_zones          = var.availability_zones
+
+  # --- DB 사양 및 계정 정보 전달 (외부에서 값 주입 필요) ---
+  instance_class = "db.t3.medium" # 요구사항에 명시된 기본값
+  db_name        = var.db_name
+  db_username    = var.db_username
+  db_password    = var.db_password
+}
+
+# ------------------------------------------------------------------------------
+# S3 버킷 모듈 호출 (이미지 저장용)
+# - modules/s3 디렉토리의 모듈을 사용하여 이미지 저장용 버킷을 생성합니다.
+# ------------------------------------------------------------------------------
+module "s3_image_bucket" {
+  source = "./modules/s3"
+
+  # --- 공통 변수 전달 ---
+  environment = terraform.workspace
+  common_tags = local.common_tags
+
+  # --- S3 버킷 설정 ---
+  bucket_name = "image" # "mapzip-{env}-image" 형태로 생성됨
+  # is_public, versioning_enabled는 모듈의 기본값(false) 사용
+}
+
+# ------------------------------------------------------------------------------
+# S3 버킷 모듈 호출 (웹사이트 리소스용)
+# - modules/s3 디렉토리의 모듈을 사용하여 웹사이트 리소스용 버킷을 생성합니다.
+# ------------------------------------------------------------------------------
+module "s3_website_bucket" {
+  source = "./modules/s3"
+
+  # --- 공통 변수 전달 ---
+  environment = terraform.workspace
+  common_tags = local.common_tags
+
+  # --- S3 버킷 설정 ---
+  bucket_name = "website" # "mapzip-{env}-website" 형태로 생성됨
+}
+
+# ------------------------------------------------------------------------------
+# EKS 모듈 호출
+# - modules/eks 디렉토리의 모듈을 사용하여 EKS 클러스터를 생성합니다.
+# ------------------------------------------------------------------------------
+module "eks" {
+  source = "./modules/eks"
+
+  # --- 공통 변수 전달 ---
+  environment = terraform.workspace
+  common_tags = local.common_tags
+  
+  # --- 네트워크 변수 전달 (외부에서 값 주입 필요) ---
+  vpc_id             = var.vpc_id
+  private_subnet_ids = var.private_subnet_ids
+}

--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -1,0 +1,69 @@
+# Aurora (PostgreSQL) 클러스터 생성
+
+# ------------------------------------------------------------------------------
+# RDS 클러스터
+# - aurora-postgresql 엔진 사용
+# - 다중 AZ(Multi-AZ) 활성화로 가용성 확보
+# - 삭제 방지(deletion_protection) 활성화로 운영 안정성 확보
+# ------------------------------------------------------------------------------
+resource "aws_rds_cluster" "aurora_cluster" {
+  # --- 기본 설정 ---
+  cluster_identifier      = "mapzip-${var.environment}-db"
+  engine                  = "aurora-postgresql"
+  engine_mode             = "provisioned"
+  database_name           = var.db_name
+  master_username         = var.db_username
+  master_password         = var.db_password # TODO: SecretsManager 연동 예정
+  port                    = 5432
+
+  # --- 네트워크 및 보안 ---
+  db_subnet_group_name    = aws_db_subnet_group.aurora_subnet_group.name
+  vpc_security_group_ids  = [var.allowed_security_group_id]
+
+  # --- 운영 및 관리 ---
+  availability_zones      = var.availability_zones
+  skip_final_snapshot     = true # 실 운영에서는 false 권장
+  deletion_protection     = true
+
+  # --- 태그 ---
+  tags = merge(
+    var.common_tags,
+    {
+      Name = "mapzip-${var.environment}-db-cluster"
+    }
+  )
+}
+
+# ------------------------------------------------------------------------------
+# RDS 클러스터 인스턴스
+# - 지정된 인스턴스 클래스 사용
+# ------------------------------------------------------------------------------
+resource "aws_rds_cluster_instance" "aurora_instance" {
+  count               = 1 # 필요에 따라 인스턴스 개수 조절
+  identifier          = "mapzip-${var.environment}-db-instance-${count.index}"
+  cluster_identifier  = aws_rds_cluster.aurora_cluster.id
+  instance_class      = var.instance_class
+  engine              = aws_rds_cluster.aurora_cluster.engine
+  engine_version      = aws_rds_cluster.aurora_cluster.engine_version
+
+  # --- 태그 ---
+  tags = merge(
+    var.common_tags,
+    {
+      Name = "mapzip-${var.environment}-db-instance"
+    }
+  )
+}
+
+# ------------------------------------------------------------------------------
+# DB 서브넷 그룹
+# - 지정된 프라이빗 서브넷에 DB 클러스터를 배치
+# ------------------------------------------------------------------------------
+resource "aws_db_subnet_group" "aurora_subnet_group" {
+  name       = "mapzip-${var.environment}-db-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = {
+    Name = "mapzip-${var.environment}-db-subnet-group"
+  }
+}

--- a/terraform/modules/aurora/outputs.tf
+++ b/terraform/modules/aurora/outputs.tf
@@ -1,0 +1,28 @@
+# Aurora 모듈 출력 변수
+
+# ------------------------------------------------------------------------------
+# 생성된 Aurora 클러스터의 주요 정보를 출력합니다.
+# - 다른 모듈이나 루트에서 이 값을 참조하여 사용할 수 있습니다.
+# ------------------------------------------------------------------------------
+
+output "cluster_endpoint" {
+  description = "Aurora DB 클러스터의 엔드포인트 주소"
+  value       = aws_rds_cluster.aurora_cluster.endpoint
+}
+
+output "cluster_port" {
+  description = "Aurora DB 클러스터의 포트 번호"
+  value       = aws_rds_cluster.aurora_cluster.port
+}
+
+output "db_name" {
+  description = "생성된 데이터베이스 이름"
+  value       = aws_rds_cluster.aurora_cluster.database_name
+  sensitive   = true
+}
+
+output "db_username" {
+  description = "데이터베이스 마스터 사용자 이름"
+  value       = aws_rds_cluster.aurora_cluster.master_username
+  sensitive   = true
+}

--- a/terraform/modules/aurora/variables.tf
+++ b/terraform/modules/aurora/variables.tf
@@ -1,50 +1,56 @@
-# 전역 변수 정의 (variables.tf)
+# Aurora 모듈 변수 정의
 
 # ------------------------------------------------------------------------------
-# AWS 리전
+# 공통 변수
+# - 루트 모듈에서 terraform.workspace와 공통 태그를 주입받습니다.
 # ------------------------------------------------------------------------------
-variable "aws_region" {
-  description = "리소스를 생성할 AWS 리전"
+variable "environment" {
+  description = "배포 환경 (e.g., dev, stg, prod)"
   type        = string
-  default     = "ap-northeast-2"
+}
+
+variable "common_tags" {
+  description = "모든 리소스에 적용될 공통 태그"
+  type        = map(string)
+  default     = {}
 }
 
 # ------------------------------------------------------------------------------
 # 네트워크 관련 변수
-# - 이 값들은 환경별 .tfvars 파일을 통해 주입되어야 합니다.
+# - VPC, 서브넷, 보안 그룹 ID는 외부에서 주입받아 사용합니다.
 # ------------------------------------------------------------------------------
 variable "vpc_id" {
-  description = "인프라가 구성될 VPC의 ID"
+  description = "DB 클러스터가 위치할 VPC의 ID"
   type        = string
 }
 
 variable "private_subnet_ids" {
-  description = "DB 등 내부 리소스가 위치할 프라이빗 서브넷 ID 목록"
+  description = "DB 클러스터가 사용할 프라이빗 서브넷 ID 목록"
   type        = list(string)
 }
 
-variable "public_subnet_ids" {
-  description = "ALB 등 외부 공개 리소스가 위치할 퍼블릭 서브넷 ID 목록"
-  type        = list(string)
-}
-
-variable "availability_zones" {
-  description = "리소스를 배치할 가용 영역(AZ) 목록"
-  type        = list(string)
-}
-
-# ------------------------------------------------------------------------------
-# 보안 그룹 관련 변수
-# ------------------------------------------------------------------------------
-variable "db_security_group_id" {
-  description = "Aurora DB 클러스터에 적용할 보안 그룹 ID"
+variable "allowed_security_group_id" {
+  description = "DB 클러스터에 적용할 보안 그룹 ID"
   type        = string
 }
 
+variable "availability_zones" {
+  description = "DB 클러스터를 배치할 가용 영역(AZ) 목록"
+  type        = list(string)
+}
+
 # ------------------------------------------------------------------------------
-# Aurora DB 계정 정보 관련 변수
-# - TODO: SecretsManager 연동 시 제거될 수 있습니다.
-# - 민감한 정보이므로 .tfvars 파일 또는 환경 변수로 전달해야 합니다.
+# DB 인스턴스 사양 관련 변수
+# ------------------------------------------------------------------------------
+variable "instance_class" {
+  description = "DB 인스턴스의 클래스 (e.g., db.t3.medium)"
+  type        = string
+  default     = "db.t3.medium"
+}
+
+# ------------------------------------------------------------------------------
+# DB 정보 관련 변수
+# - TODO: 추후 SecretsManager와 연동하여 관리해야 합니다.
 # ------------------------------------------------------------------------------
 variable "db_name" {
   description = "생성할 데이터베이스의 이름"

--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -1,0 +1,92 @@
+# ------------------------------------------------------------------------------
+# EKS 클러스터용 IAM 역할
+# ------------------------------------------------------------------------------
+resource "aws_iam_role" "cluster" {
+  name = "mapzip-${var.environment}-eks-cluster-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "eks.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_amazon_eks_cluster_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+# ------------------------------------------------------------------------------
+# EKS 노드 그룹용 IAM 역할
+# ------------------------------------------------------------------------------
+resource "aws_iam_role" "node" {
+  name = "mapzip-${var.environment}-eks-node-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "node_amazon_eks_worker_node_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_amazon_ec2_container_registry_read_only" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node.name
+}
+
+# ------------------------------------------------------------------------------
+# EKS 클러스터 생성
+# ------------------------------------------------------------------------------
+resource "aws_eks_cluster" "main" {
+  name     = "mapzip-${var.environment}-cluster"
+  role_arn = aws_iam_role.cluster.arn
+  version  = "1.28"
+
+  vpc_config {
+    subnet_ids = var.private_subnet_ids
+  }
+
+  tags = var.common_tags
+}
+
+# ------------------------------------------------------------------------------
+# EKS 노드 그룹 생성
+# ------------------------------------------------------------------------------
+resource "aws_eks_node_group" "main" {
+  cluster_name    = aws_eks_cluster.main.name
+  node_group_name = "mapzip-${var.environment}-nodegroup"
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = var.private_subnet_ids
+
+  instance_types = ["t3.medium"]
+  scaling_config {
+    desired_size = 2
+    max_size     = 3
+    min_size     = 1
+  }
+
+  tags = var.common_tags
+}

--- a/terraform/modules/eks/outputs.tf
+++ b/terraform/modules/eks/outputs.tf
@@ -1,0 +1,4 @@
+output "cluster_name" {
+  description = "The name of the EKS cluster"
+  value       = aws_eks_cluster.main.name
+}

--- a/terraform/modules/eks/variables.tf
+++ b/terraform/modules/eks/variables.tf
@@ -1,0 +1,19 @@
+variable "environment" {
+  description = "The deployment environment (e.g., dev, prd)"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "A list of private subnet IDs"
+  type        = list(string)
+}

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -1,0 +1,89 @@
+# S3 버킷 리소스 생성
+
+# ------------------------------------------------------------------------------
+# S3 버킷
+# - 기본적으로 비공개(private)로 설정됩니다.
+# - 서버 측 암호화(SSE-S3)를 사용합니다.
+# - 버전 관리는 비활성화되어 있습니다.
+# ------------------------------------------------------------------------------
+resource "aws_s3_bucket" "this" {
+  # --- 네이밍 ---
+  # 버킷 이름은 전역적으로 고유해야 하므로, 환경과 이름을 조합하여 생성합니다.
+  bucket = "mapzip-${var.environment}-${var.bucket_name}"
+
+  # --- 태그 ---
+  tags = merge(
+    var.common_tags,
+    {
+      Name = "mapzip-${var.environment}-${var.bucket_name}"
+    }
+  )
+}
+
+# ------------------------------------------------------------------------------
+# S3 버킷 소유권 설정
+# - ACL 비활성화를 위해 BucketOwnerEnforced 설정을 권장합니다.
+# ------------------------------------------------------------------------------
+resource "aws_s3_bucket_ownership_controls" "this" {
+  bucket = aws_s3_bucket.this.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+# ------------------------------------------------------------------------------
+# S3 버킷 공개 접근 차단
+# - is_public 변수 값에 따라 모든 공개 접근을 차단하거나 허용합니다.
+# - TODO: 추후 public 여부 논의 필요
+# ------------------------------------------------------------------------------
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = !var.is_public
+  block_public_policy     = !var.is_public
+  ignore_public_acls      = !var.is_public
+  restrict_public_buckets = !var.is_public
+}
+
+# ------------------------------------------------------------------------------
+# S3 버킷 서버 측 암호화 설정
+# - 기본 암호화로 SSE-S3 (AES256)를 사용합니다.
+# ------------------------------------------------------------------------------
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# ------------------------------------------------------------------------------
+# S3 버킷 버전 관리 설정
+# - TODO: 추후 변경 가능성 있음
+# ------------------------------------------------------------------------------
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = var.versioning_enabled ? "Enabled" : "Disabled"
+  }
+}
+
+# ------------------------------------------------------------------------------
+# S3 정적 웹 호스팅 (주석 처리)
+# - 필요 시 아래 주석을 해제하여 사용할 수 있습니다.
+# ------------------------------------------------------------------------------
+/*
+resource "aws_s3_bucket_website_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+}
+*/

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -1,0 +1,20 @@
+# S3 모듈 출력 변수
+
+# ------------------------------------------------------------------------------
+# 생성된 S3 버킷의 주요 정보를 출력합니다.
+# ------------------------------------------------------------------------------
+
+output "bucket_name" {
+  description = "생성된 S3 버킷의 전체 이름"
+  value       = aws_s3_bucket.this.bucket
+}
+
+output "bucket_arn" {
+  description = "생성된 S3 버킷의 ARN"
+  value       = aws_s3_bucket.this.arn
+}
+
+output "bucket_domain_name" {
+  description = "S3 버킷의 도메인 이름"
+  value       = aws_s3_bucket.this.bucket_domain_name
+}

--- a/terraform/modules/s3/variables.tf
+++ b/terraform/modules/s3/variables.tf
@@ -1,0 +1,35 @@
+# S3 모듈 변수 정의
+
+# ------------------------------------------------------------------------------
+# 공통 변수
+# ------------------------------------------------------------------------------
+variable "environment" {
+  description = "배포 환경 (e.g., dev, stg, prod)"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "모든 리소스에 적용될 공통 태그"
+  type        = map(string)
+  default     = {}
+}
+
+# ------------------------------------------------------------------------------
+# S3 버킷 설정 관련 변수
+# ------------------------------------------------------------------------------
+variable "bucket_name" {
+  description = "생성할 S3 버킷의 이름 (prefix 제외)"
+  type        = string
+}
+
+variable "is_public" {
+  description = "버킷의 Public 접근 허용 여부"
+  type        = bool
+  default     = false # 기본적으로 비공개
+}
+
+variable "versioning_enabled" {
+  description = "버킷의 버전 관리 활성화 여부"
+  type        = bool
+  default     = false # 기본적으로 비활성화
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,38 @@
+# 루트 모듈 출력 변수 (outputs.tf)
+
+# ------------------------------------------------------------------------------
+# Aurora DB 정보 출력
+# - 모듈의 출력을 참조하여 필요한 정보를 노출합니다.
+# ------------------------------------------------------------------------------
+output "aurora_cluster_endpoint" {
+  description = "Aurora DB 클러스터의 엔드포인트 주소"
+  value       = module.aurora_db.cluster_endpoint
+}
+
+output "aurora_cluster_port" {
+  description = "Aurora DB 클러스터의 포트 번호"
+  value       = module.aurora_db.cluster_port
+}
+
+# ------------------------------------------------------------------------------
+# S3 버킷 정보 출력
+# ------------------------------------------------------------------------------
+output "s3_image_bucket_name" {
+  description = "이미지 저장용 S3 버킷의 전체 이름"
+  value       = module.s3_image_bucket.bucket_name
+}
+
+output "s3_image_bucket_arn" {
+  description = "이미지 저장용 S3 버킷의 ARN"
+  value       = module.s3_image_bucket.bucket_arn
+}
+
+output "s3_website_bucket_name" {
+  description = "웹사이트 리소스용 S3 버킷의 전체 이름"
+  value       = module.s3_website_bucket.bucket_name
+}
+
+output "s3_website_bucket_arn" {
+  description = "웹사이트 리소스용 S3 버킷의 ARN"
+  value       = module.s3_website_bucket.bucket_arn
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -22,6 +22,7 @@ provider "aws" {
   region = "ap-northeast-2"
 }
 
+/*
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_name
 }
@@ -43,3 +44,4 @@ provider "helm" {
     token                  = data.aws_eks_cluster_auth.cluster.token
   }
 }
+*/


### PR DESCRIPTION
# Aurora DB 및 S3 버킷 인프라 추가 및 테스트 환경 구성

## PR 개요

이 PR은 신규 `Aurora (PostgreSQL)` 및 `S3` 모듈을 추가하고, 이를 `dev` 환경에서 테스트하기 위한 초기 구성을 포함합니다.

로컬 및 Terraform Cloud에서 `terraform plan/apply`를 실행하여 의존성 문제를 해결하는 과정에서, 다른 팀원이 담당하는 `EKS` 및 `provider` 관련 임시 수정사항이 포함되었습니다.

## 주요 변경 사항

### 1. 신규 모듈 추가
- **`modules/aurora`**: Aurora PostgreSQL DB 클러스터 및 인스턴스를 생성하는 모듈을 추가했습니다.
- **`modules/s3`**: 이미지 저장용 및 웹사이트 리소스용 S3 버킷을 생성하는 공용 모듈을 추가했습니다.

### 2. EKS 모듈 임시 추가 (`/modules/eks`)
- **목적**: `providers.tf` 파일이 `module.eks.cluster_name`을 참조하고 있어, `plan` 실행을 위해 최소한의 EKS 모듈 구조가 필요했습니다.
- **내용**: EKS 클러스터, 노드 그룹 및 관련 IAM 역할을 생성하는 기본 리소스를 포함하고 있습니다.
- **⚠️ 리뷰 요청**: **이 모듈은 Aurora/S3 테스트를 위한 임시 방편입니다.** EKS 담당자분께서 실제 운영에 필요한 구성으로 검토 및 교체해 주셔야 합니다.

### 3. Provider 설정 임시 비활성화 (`/providers.tf`)
- **목적**: 아직 생성되지 않은 EKS 클러스터 정보를 `data` 블록으로 조회하려다 발생하는 오류를 해결하기 위함입니다.
- **내용**: `kubernetes` 및 `helm` 프로바이더와 관련된 `data` 블록을 주석 처리했습니다.
- **리뷰 요청**: EKS 클러스터가 준비된 후, 해당 주석을 해제하고 올바른 클러스터 정보를 참조하도록 수정이 필요합니다.

## 리뷰어에게

- **EKS & 네트워크 담당자**: `modules/eks`는 테스트를 위해 제가 임시로 만든 것입니다. 실제 EKS 구성으로 대체해 주시고, `providers.tf`의 주석 처리된 부분도 EKS 클러스터 생성 후 복원 부탁드립니다.

이 PR이 머지되면 Terraform Cloud `dev` 워크스페이스에서 Aurora DB와 S3 버킷이 정상적으로 생성되는 것을 목표로 합니다.
