### PR TITLE
dynamodb&elasticahce 생성

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,15 @@
+module "dynamodb" {
+  source       = "./modules/dynamodb"
+  environment  = terraform.workspace
+  table_name   = "reviews"
+  common_tags  = local.common_tags
+}
+
+module "elasticache" {
+  source                        = "./modules/elasticache"
+  environment                   = terraform.workspace
+  cluster_name                  = "session-cache"
+  common_tags                   = local.common_tags
+  elasticache_subnet_group_name = module.network.elasticache_subnet_group_name # From network module
+  security_group_ids            = [module.network.elasticache_security_group_id] # From network module
+}

--- a/terraform/modules/dynamodb/main.tf
+++ b/terraform/modules/dynamodb/main.tf
@@ -1,0 +1,25 @@
+resource "aws_dynamodb_table" "this" {
+  # --- 네이밍 ---
+  name           = "mapzip-${var.environment}-${var.table_name}"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "restaurant_id"
+  range_key      = "review_id"
+
+  attribute {
+    name = "restaurant_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "review_id"
+    type = "S"
+  }
+
+  # --- 태그 ---
+  tags = merge(
+    var.common_tags,
+    {
+      Name = "mapzip-${var.environment}-${var.table_name}"
+    }
+  )
+}

--- a/terraform/modules/dynamodb/outputs.tf
+++ b/terraform/modules/dynamodb/outputs.tf
@@ -1,0 +1,8 @@
+
+output "dynamodb_table_name" {
+  value = aws_dynamodb_table.reviews_table.name
+}
+
+output "dynamodb_table_arn" {
+  value = aws_dynamodb_table.reviews_table.arn
+}

--- a/terraform/modules/dynamodb/variables.tf
+++ b/terraform/modules/dynamodb/variables.tf
@@ -1,0 +1,15 @@
+variable "environment" {
+  description = "Deployment environment (e.g., dev, staging, prod)"
+  type        = string
+}
+
+variable "table_name" {
+  description = "The specific name for the DynamoDB table"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/elasticache/main.tf
+++ b/terraform/modules/elasticache/main.tf
@@ -1,0 +1,20 @@
+resource "aws_elasticache_cluster" "this" {
+  # --- 네이밍 ---
+  cluster_id           = "mapzip-${var.environment}-${var.cluster_name}"
+
+  engine               = "redis"
+  node_type            = "cache.t3.micro"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis7"
+  port                 = 6379
+  subnet_group_name    = var.elasticache_subnet_group_name
+  security_group_ids   = var.security_group_ids
+
+  # --- 태그 ---
+  tags = merge(
+    var.common_tags,
+    {
+      Name = "mapzip-${var.environment}-${var.cluster_name}"
+    }
+  )
+}

--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -1,0 +1,8 @@
+
+output "elasticache_cluster_id" {
+  value = aws_elasticache_cluster.valkey_cluster.cluster_id
+}
+
+output "elasticache_cluster_endpoint" {
+  value = aws_elasticache_cluster.valkey_cluster.cache_nodes[0].address
+}

--- a/terraform/modules/elasticache/variables.tf
+++ b/terraform/modules/elasticache/variables.tf
@@ -1,0 +1,25 @@
+variable "environment" {
+  description = "Deployment environment (e.g., dev, staging, prod)"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "The specific name for the ElastiCache cluster"
+  type        = string
+}
+
+variable "elasticache_subnet_group_name" {
+  description = "Subnet group name for ElastiCache"
+  type        = string
+}
+
+variable "security_group_ids" {
+  description = "List of security group IDs for ElastiCache"
+  type        = list(string)
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "dynamodb_table_name" {
+  description = "The name of the DynamoDB reviews table"
+  value       = module.dynamodb.aws_dynamodb_table_this_name
+}
+
+output "dynamodb_table_arn" {
+  description = "The ARN of the DynamoDB reviews table"
+  value       = module.dynamodb.aws_dynamodb_table_this_arn
+}
+
+output "elasticache_cluster_id" {
+  description = "The ID of the ElastiCache cluster"
+  value       = module.elasticache.aws_elasticache_cluster_this_id
+}
+
+output "elasticache_cluster_endpoint" {
+  description = "The endpoint of the ElastiCache cluster"
+  value       = module.elasticache.aws_elasticache_cluster_this_cache_nodes_0_address
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -11,8 +11,7 @@ variable "service_domain" {
 }
 
 locals {
-  common_prefix = "mapzip-${terraform.workspace}-"
-  common_tags  = {
+  common_tags = {
     Environment = terraform.workspace
     Project     = "mapzip"
     ManagedBy   = "Terraform"


### PR DESCRIPTION
✅ 요약

  feat: DynamoDB 및 ElastiCache 모듈 추가

  변경 내용


   - `terraform/modules/dynamodb/`
       - 리뷰 데이터 저장을 위한 DynamoDB 테이블 모듈을 신규 추가했습니다.
   - `terraform/modules/elasticache/`
       - 세션 캐시용 ElastiCache(Valkey) 클러스터 모듈을 신규 추가했습니다.
   - `terraform/main.tf`
       - 생성된 dynamodb, elasticache 모듈을 호출하고, network 모듈과의 의존성을 명시하도록 수정했습니다.
   - `terraform/variables.tf` & `outputs.tf`
       - 프로젝트 네이밍 규칙(mapzip-{환경}-{이름})과 공통 태그(locals.common_tags)를 적용하고, 모듈의 결과물을 루트에서 출력하도록 수정했습니다.

  확인 필요사항
   - `network` 모듈 연동: main.tf의 elasticache 모듈은 network 모듈의 출력 값(cache_subnet_group_name, cache_security_group_id)을 사용하도록 설정되어 있습니다. 네트워크부분 끝나면 이 부분을 연결하겠습니다.
   - Terraform Cloud 백엔드: backend.tf에 Terraform Cloud 설정이 있어 로컬에서 plan 실행 시 인증 오류가 발생할 수 있습니다.

  메모

