### PR TITLE
fix:eks 런치템플릿 userdata수정

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -280,13 +280,13 @@ module "client_vpn" {
   ]
   
   # 라우팅 규칙
-  routes = [
-    {
-      destination_cidr_block = module.vpc.vpc_cidr_block
-      target_vpc_subnet_id   = module.private_subnets.subnet_ids[0]
-      description            = "Route to VPC"
-    }
-  ]
+  # routes = [
+  #   {
+  #     destination_cidr_block = module.vpc.vpc_cidr_block
+  #     target_vpc_subnet_id   = module.private_subnets.subnet_ids[0]
+  #     description            = "Route to VPC"
+  #   }
+  # ]
   
   # 보안 그룹 규칙
   security_group_ingress_rules = [

--- a/terraform/modules/eks/security_group.tf
+++ b/terraform/modules/eks/security_group.tf
@@ -67,6 +67,13 @@ resource "aws_security_group" "aws_eks_node_group" {
   }
 
   ingress {
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = ["192.168.219.0/24"]
+  }
+
+  ingress {
     from_port       = 1025
     to_port         = 65535
     protocol        = "tcp"


### PR DESCRIPTION
## ✅ 요약
eks 런치템플릿 userdata수정

## 🧩 변경 내용
- eks 런치템플릿에서 AL2023부터 bootstrap.sh를 지원하지 않아서 nodeam방식으로 수정
- client vpn 라우팅규칙 주석처리 (디폴트 라우팅이 생성되어 중복생성할 필요 없음)

## 🔍 확인 필요사항 (선택)
테스트가 필요한 부분이나, 다음 작업과 연관되는 부분 정리

## 📝 메모 
[nodeam 참고](https://docs.aws.amazon.com/ko_kr/eks/latest/userguide/launch-templates.html)