### PR TITLE
fix: 오로라 db 클러스터 삭제 후 재생성

### DIFF
--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -81,7 +81,7 @@ resource "aws_rds_cluster" "this" {
   # --- 운영 및 관리 ---
   availability_zones      = var.availability_zones
   skip_final_snapshot     = true
-  deletion_protection     = true
+    deletion_protection     = false
 
   # --- 태그 ---
   tags = merge(


### PR DESCRIPTION
## ✅ 요약
db명을 변경하기 위해 테라폼이 클러스터를 삭제했다가 다시 생성하려했지만
현재 설정상 클러스터에 삭제방지가 걸려있어서 삭제가 안되어서 에러가 난 부분을 수정합니다.

## 🧩 변경 내용
- terraform\modules\aurora\main.tf

## 🔍 확인 필요사항 (선택)
테스트가 필요한 부분이나, 다음 작업과 연관되는 부분 정리

## 📝 메모 
내가 기억하고 싶은 내용, 후속 작업 아이디어 등
