### PR TITLE
fix: cloudfront aliases 추가

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -144,7 +144,8 @@ module "cloudfront" {
   acm_certificate_arn = module.acm_frontend.certificate_arn
   common_prefix       = local.common_prefix
   common_tags         = local.common_tags
-  depends_on = [module.acm_frontend]
+  depends_on          = [module.acm_frontend]
+  aliases             = ["www.mapzip.shop"]
 }
 //cloudfront- a record
 module "a_record_frontend" {
@@ -164,7 +165,8 @@ module "cloudfront_image" {
   acm_certificate_arn = module.acm_image.certificate_arn
   common_prefix       = local.common_prefix
   common_tags         = local.common_tags
-  depends_on = [module.acm_image]
+  depends_on          = [module.acm_image]
+  aliases             = ["img.mapzip.shop"]
 }
 
 //cloudfront(이미지연결)-a record

--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -7,6 +7,7 @@ resource "aws_cloudfront_distribution" "this" {
       origin_access_identity = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path
     }
   }
+  aliases = var.aliases
 
   enabled             = true
   is_ipv6_enabled     = true

--- a/terraform/modules/cloudfront/variables.tf
+++ b/terraform/modules/cloudfront/variables.tf
@@ -16,3 +16,8 @@ variable "common_tags" {
   type = map(string)
 }
 
+variable "aliases" {
+  description = "CloudFront 배포에 사용할 도메인 이름 목록"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## ✅ 요약
cloudfront에 aliases가 없으면 CloudFront는 커스텀 도메인 요청을 인식하지 못하고, HTTPS 연결도 실패하여 추가해줬습니다.
