### PR TITLE
fix: Auth 서비스 이미지 태그를 실제 ECR 태그로 업데이트

### DIFF
--- a/argocd/platform/auth.yaml
+++ b/argocd/platform/auth.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: auth-service-container
-        image: 061039804626.dkr.ecr.ap-northeast-2.amazonaws.com/mapzip-dev-ecr-auth:latest
+        image: 061039804626.dkr.ecr.ap-northeast-2.amazonaws.com/mapzip-dev-ecr-auth:4933b31
         ports:
         - protocol: TCP
           containerPort: 8080


### PR DESCRIPTION
- Auth 서비스 이미지 태그를 latest에서 4933b31로 변경
- GitHub Actions에서 방금 빌드된 최신 이미지 사용
- ECR에 실제로 존재하는 태그로 수정하여 ImagePullBackOff 문제 해결
- ArgoCD에서 정상적으로 auth 서비스 배포 가능
- Config Server 연결 테스트를 위한 완전한 배포 환경 구성