### PR TITLE
fix: Auth 서비스 Config Server 연결 수정 버전으로 이미지 업데이트

### DIFF
--- a/argocd/platform/auth.yaml
+++ b/argocd/platform/auth.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: auth-service-container
-        image: 061039804626.dkr.ecr.ap-northeast-2.amazonaws.com/mapzip-dev-ecr-auth:4933b31
+        image: 061039804626.dkr.ecr.ap-northeast-2.amazonaws.com/mapzip-dev-ecr-auth:2c98042
         ports:
         - protocol: TCP
           containerPort: 8080


### PR DESCRIPTION
- Auth 서비스 이미지 태그를 4933b31에서 2c98042로 업데이트
- Config Server URL 수정이 포함된 최신 버전 사용
- config-server → config로 Service 이름 수정된 버전
- 이제 Auth 서비스가 올바른 Config Server URL로 연결 시도
- Config Server에서 설정을 정상적으로 가져올 수 있음