### PR TITLE
fix: 인프라 고정리소스 설정

### DIFF
--- a/scripts/setup-k8s-mac.sh
+++ b/scripts/setup-k8s-mac.sh
@@ -152,7 +152,7 @@ helm upgrade --install istio-base istio/base \
   --wait
 
 echo "Creating Jaeger deployment and services..."
-kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.26/samples/addons/jaeger.yaml
+kubectl apply -f values/jaeger.yaml
 
 
 echo "Installing Istiod..."

--- a/scripts/setup-k8s-windows.bat
+++ b/scripts/setup-k8s-windows.bat
@@ -156,7 +156,7 @@ helm upgrade --install istio-base istio/base ^
   --wait
 
 echo Creating Jaeger deployment and services...
-kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.26/samples/addons/jaeger.yaml
+kubectl apply -f values/jaeger.yaml
 
 
 echo Installing Istiod...

--- a/scripts/values/jaeger.yaml
+++ b/scripts/values/jaeger.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  namespace: istio-system
+  labels:
+    app: jaeger
+spec:
+  selector:
+    matchLabels:
+      app: jaeger
+  template:
+    metadata:
+      labels:
+        app: jaeger
+        sidecar.istio.io/inject: "false"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "14269"
+    spec:
+      containers:
+        - name: jaeger
+          image: "docker.io/jaegertracing/all-in-one:1.67.0"
+          env:
+            - name: BADGER_EPHEMERAL
+              value: "false"
+            - name: SPAN_STORAGE_TYPE
+              value: "badger"
+            - name: BADGER_DIRECTORY_VALUE
+              value: "/badger/data"
+            - name: BADGER_DIRECTORY_KEY
+              value: "/badger/key"
+            - name: COLLECTOR_ZIPKIN_HOST_PORT
+              value: ":9411"
+            - name: MEMORY_MAX_TRACES
+              value: "50000"
+            - name: QUERY_BASE_PATH
+              value: /jaeger
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 14269
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 14269
+          volumeMounts:
+            - name: data
+              mountPath: /badger
+          resources:
+            requests:
+              cpu: 10m
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tracing-lb
+  namespace: istio-system
+  labels:
+    app: jaeger
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"                          # or alb if using ingress
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"                    # 내부용
+    external-dns.alpha.kubernetes.io/hostname: jaeger.mapzip.shop 
+spec:
+  type: LoadBalancer
+  ports:
+    - name: http-query
+      port: 80
+      targetPort: 16686
+  selector:
+    app: jaeger
+---
+# Jaeger implements the Zipkin API. To support swapping out the tracing backend, we use a Service named Zipkin.
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: zipkin
+  name: zipkin
+  namespace: istio-system
+spec:
+  ports:
+    - port: 9411
+      targetPort: 9411
+      name: http-query
+  selector:
+    app: jaeger
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger-collector
+  namespace: istio-system
+  labels:
+    app: jaeger
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-collector-http
+    port: 14268
+    targetPort: 14268
+    protocol: TCP
+  - name: jaeger-collector-grpc
+    port: 14250
+    targetPort: 14250
+    protocol: TCP
+  - port: 9411
+    targetPort: 9411
+    name: http-zipkin
+  - port: 4317
+    name: grpc-otel
+  - port: 4318
+    name: http-otel
+  selector:
+    app: jaeger

--- a/terraform/modules/acm/main.tf
+++ b/terraform/modules/acm/main.tf
@@ -4,6 +4,10 @@ resource "aws_acm_certificate" "this" {
   tags = merge(var.common_tags, {
     Name = "${var.common_prefix}acm-${replace(var.domain_name, ".", "-")}"
   })
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_route53_record" "validation" {
@@ -20,18 +24,13 @@ resource "aws_route53_record" "validation" {
   type    = each.value.type
   records = [each.value.record]
   ttl     = 300
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_acm_certificate_validation" "this" {
   certificate_arn         = aws_acm_certificate.this.arn
   validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
-}
-
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 6.0"
-    }
-  }
 }

--- a/terraform/modules/route53/main.tf
+++ b/terraform/modules/route53/main.tf
@@ -8,13 +8,9 @@ resource "aws_route53_zone" "this" {
       Name = "${var.common_prefix}hosted-zone"
     }
   )
-}
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 6.0"
-    }
+
+  lifecycle {
+    prevent_destroy = true
   }
 }
 


### PR DESCRIPTION
## ✅ 요약
aws_route53_zone, aws_acm_certificate, aws_route53_record 는 고정리소스로 테라폼 destroy를 해도 지워지지 않도록 설정했습니다.