### PR TITLE
fix: 고정리소스 설정 취소

### DIFF
--- a/terraform/modules/acm/main.tf
+++ b/terraform/modules/acm/main.tf
@@ -5,9 +5,6 @@ resource "aws_acm_certificate" "this" {
     Name = "${var.common_prefix}acm-${replace(var.domain_name, ".", "-")}"
   })
 
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_route53_record" "validation" {
@@ -25,9 +22,6 @@ resource "aws_route53_record" "validation" {
   records = [each.value.record]
   ttl     = 300
 
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_acm_certificate_validation" "this" {

--- a/terraform/modules/route53/main.tf
+++ b/terraform/modules/route53/main.tf
@@ -9,8 +9,5 @@ resource "aws_route53_zone" "this" {
     }
   )
 
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 


### PR DESCRIPTION
## ✅ 요약
테라폼 클라우드에서 destroy시 plan단계에서 prevent destroy설정때문에 error가 나서 리소스 전체가 삭제되지 않아 고정 리소스 설정을 취소했습니다.
