### PR TITLE
test: envoyFilter 테스트용 데모앱 배포

### DIFF
--- a/argocd/demo/demo.yaml
+++ b/argocd/demo/demo.yaml
@@ -1,0 +1,126 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo
+spec:
+  selector:
+    app.kubernetes.io/name: demo-pod
+  type: ClusterIP
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 9090
+      targetPort: 9090
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: demo-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: demo-deployment
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-deployment
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: demo-pod
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: demo-pod
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/actuator/prometheus"
+        sidecar.istio.io/userVolume: |
+          [
+            {
+              "name": "pb-volume",
+              "emptyDir": {}
+            }
+          ]
+        sidecar.istio.io/userMount: |
+          [
+            {
+              "name": "pb-volume",
+              "mountPath": "/etc/envoy/protos",
+              "readonly": true
+            }
+          ]
+    spec:
+      containers:
+      - name: demo-container
+        image: siyunp/demo-grpc-app:latest
+        ports:
+        - protocol: TCP
+          containerPort: 9090  # gRPC
+        - protocol: TCP
+          containerPort: 8080  # HTTP
+
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "300m"
+            memory: "256Mi"
+
+        livenessProbe:
+          httpGet:
+            path: /actuator/health
+            port: 8080
+          initialDelaySeconds: 90
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 3
+        
+        readinessProbe:
+          httpGet:
+            path: /actuator/health
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 2
+
+      initContainers:
+      - name: copy-pb
+        image: siyunp/demo-pb:latest
+        command: ["/bin/sh", "-c"]
+        args: ["cp /data/proto.pb /shared/"]
+        volumeMounts:
+          - name: pb-volume
+            mountPath: /shared
+
+      volumes:
+        - name: pb-volume
+          emptyDir: {}

--- a/argocd/demo/envoy-grfc-http.yaml
+++ b/argocd/demo/envoy-grfc-http.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: grpc-json-transcoder-filter
+spec:
+  workloadSelector:
+    labels:
+      app.kubernetes.io/name: demo
+  configPatches:
+    # The first patch adds the lua filter to the listener/http connection manager
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        portNumber: 9090
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+            subFilter:
+              name: "envoy.filters.http.router"
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: envoy.filters.http.grpc_json_transcoder
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder"
+          proto_descriptor: "/etc/envoy/protos/proto.pb"
+          services: 
+            - hello.HelloService
+          print_options:
+            add_whitespace: true
+            always_print_primitive_fields: true
+            always_print_enums_as_ints: false
+

--- a/scripts/values/argocd-applications.yaml
+++ b/scripts/values/argocd-applications.yaml
@@ -81,3 +81,24 @@ spec:
       selfHeal: true
     syncOptions:
     - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mapzip-dev-demo
+  namespace: argocd
+spec:
+  destination:
+    namespace: demo
+    server: https://kubernetes.default.svc
+  source:
+    path: argocd/demo
+    repoURL: https://github.com/CLD3rd-Team4/Infra
+    targetRevision: dev
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true


### PR DESCRIPTION
## ✅ 요약
envoyFilter 테스트용 데모앱 배포

## 🧩 변경 내용
- demo 앱 ArgoCD 배포 (도커허브에서 이미지로 가져옴)
  - /hello 요청에 "it's demo {요청헤더들...}" 응답하도록 설정함
  - 8080포트에서 promethus 등 healthcheck 요청을 http로 받음
  - 9090포트에서 grpc 요청(/hello)을 받음
- 로컬에서 demo앱이 http요청과 grpc 요청에 잘 응답함을 확인함
- envoyfilter설정을 추가하고 .pb는 도커이미지로 만들어서 emptyDir(Pod 내 여러 컨테이너 간에 데이터를 공유할 수 있도록 해주는 임시 볼륨)로 istio 사이드카에서 사용할 수 있게 설정함

## 🔍 확인 필요사항 (선택)
실제 eks에 올려서 테스트가 필요합니다.

