### PR TITLE
Add Google Cloud Vision API key support for review service

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -516,8 +516,9 @@ module "github_oidc_role" {
 module "config_server_ssm" {
   source = "./modules/ssm"
 
-  git_username = var.git_username
-  git_token    = var.git_token
-  encrypt_key  = var.config_server_encrypt_key
-  common_tags  = local.common_tags
+  git_username           = var.git_username
+  git_token              = var.git_token
+  encrypt_key            = var.config_server_encrypt_key
+  google_vision_api_key  = var.google_vision_api_key
+  common_tags            = local.common_tags
 }

--- a/terraform/modules/ssm/main.tf
+++ b/terraform/modules/ssm/main.tf
@@ -32,3 +32,16 @@ resource "aws_ssm_parameter" "encrypt_key" {
 
   tags = var.common_tags
 }
+
+# Google Cloud Vision API 키 (Review 서비스용)
+resource "aws_ssm_parameter" "google_vision_api_key" {
+  count = var.google_vision_api_key != "" ? 1 : 0
+  
+  name        = "/mapzip/review/google-vision-api-key"
+  description = "Google Cloud Vision API key for review service"
+  type        = "SecureString"
+  value       = var.google_vision_api_key
+  overwrite   = true
+
+  tags = var.common_tags
+}

--- a/terraform/modules/ssm/variables.tf
+++ b/terraform/modules/ssm/variables.tf
@@ -17,6 +17,13 @@ variable "encrypt_key" {
   default     = ""
 }
 
+variable "google_vision_api_key" {
+  description = "Google Cloud Vision API key for review service"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "common_tags" {
   description = "Common tags to apply to all resources"
   type        = map(string)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -141,3 +141,10 @@ variable "config_server_encrypt_key" {
   sensitive   = true
   default     = ""
 }
+
+variable "google_vision_api_key" {
+  description = "Google Cloud Vision API key for review service"
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
## 🎯 목적
Review 서비스의 Config Server 연동을 위한 Google Cloud Vision API 키 지원 추가

## 📋 변경사항
- **Terraform 변수 추가**: `google_vision_api_key` 변수 추가
- **SSM 모듈 업데이트**: Google Vision API 키를 SSM Parameter Store에 저장
- **Sealed Secret 스크립트 업데이트**: `google-cloud-vision-secret` 생성 지원
- **Config Server 연동 지원**: Review 서비스가 외부 API 키를 안전하게 사용할 수 있도록 설정

## 🔧 주요 파일 변경
- `terraform/variables.tf`: google_vision_api_key 변수 추가
- `terraform/main.tf`: SSM 모듈 호출에 변수 추가
- `terraform/modules/ssm/`: Google Vision API 키 Parameter 생성
- `scripts/generate-sealed-secrets.sh`: Google Vision Secret 생성 로직 추가

## 🚀 다음 단계
1. Terraform Cloud에서 `google_vision_api_key` 변수 설정
2. Terraform apply 실행
3. Sealed Secret 재생성
4. Review 서비스 Config Server 연동 테스트

## ✅ 테스트
- [ ] Terraform plan 성공 확인
- [ ] SSM Parameter 생성 확인  
- [ ] Sealed Secret 생성 확인
- [ ] Review 서비스 배포 테스트