### PR TITLE
fix: terraform apply 시 노드그룹 수시로 변경되지 않게 수정

### DIFF
--- a/scripts/values/alb-ingress-to-istio-ingress.yaml
+++ b/scripts/values/alb-ingress-to-istio-ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/healthcheck-path: /healthz/ready
     alb.ingress.kubernetes.io/healthcheck-port: traffic-port
-    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-northeast-2:061039804626:certificate/ec9eae87-d35b-49d3-9bea-a5fda4ce12e1
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-northeast-2:061039804626:certificate/32bbdfb0-f75c-4e10-b803-1309bd437d4d
     alb.ingress.kubernetes.io/listen-ports: |
       [
         { "HTTP": 80 },

--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -44,4 +44,11 @@ resource "aws_eks_node_group" "this" {
   }
 
   tags = var.common_tags
+
+  lifecycle {
+    ignore_changes = [
+      scaling_config[0].desired_size,
+      launch_template[0].version
+    ]
+  }
 }


### PR DESCRIPTION
## ✅ 요약
테라폼 lifecycle을 설정하여 테라폼 apply마다 노드그룹의 desired_size 에 따라 pod를 재배치하지 않도록 수정했습니다.
