### PR TITLE
infra: s3,dynamoDB vpc endpoint설정, output sensitive 설정

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -168,6 +168,7 @@ module "cloudfront" {
   depends_on          = [module.acm_frontend]
   aliases             = ["www.mapzip.shop"]
 }
+
 //cloudfront- a record
 module "a_record_frontend" {
   source        = "./modules/record"
@@ -544,4 +545,26 @@ module "config_server_ssm" {
   git_token              = var.git_token
   encrypt_key            = var.config_server_encrypt_key
   common_tags            = local.common_tags
+}
+
+module "vpc_endpoints" {
+  source = "./modules/network/vpc-endpoints"
+
+  vpc_id             = module.vpc.vpc_id
+  region             = var.aws_region
+  route_table_ids    = [module.private_route_table.route_table_id]
+  subnet_ids         = module.private_subnets.subnet_ids 
+
+  services = [
+    {
+      name                = "dynamodb"
+      type                = "Gateway"
+    },
+    {
+      name                = "s3"
+      type                = "Gateway"
+    }
+  ]
+
+  common_tags = local.common_tags
 }

--- a/terraform/modules/eks/outputs.tf
+++ b/terraform/modules/eks/outputs.tf
@@ -4,10 +4,12 @@ output "cluster_name" {
 
 output "cluster_endpoint" {
   value = aws_eks_cluster.this.endpoint
+  sensitive = true
 }
 
 output "cluster_certificate_authority" {
   value = aws_eks_cluster.this.certificate_authority[0].data
+  sensitive = true
 }
 
 output "aws_load_balancer_controller_role_arn" {

--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -5,4 +5,5 @@ output "elasticache_cluster_id" {
 
 output "elasticache_cluster_endpoint" {
   value = aws_elasticache_replication_group.this.configuration_endpoint_address != null ? aws_elasticache_replication_group.this.configuration_endpoint_address : aws_elasticache_replication_group.this.primary_endpoint_address
+  sensitive = true
 }

--- a/terraform/modules/msk/outputs.tf
+++ b/terraform/modules/msk/outputs.tf
@@ -6,14 +6,17 @@ output "msk_cluster_arn" {
 output "msk_cluster_bootstrap_brokers" {
   description = "A comma separated list of one or more DNS names and client ports that you can use to connect to the broker (plaintext)."
   value       = aws_msk_cluster.this.bootstrap_brokers
+  sensitive   = true
 }
 
 output "msk_cluster_bootstrap_brokers_tls" {
   description = "A comma separated list of one or more DNS names and client ports that you can use to connect to the broker for TLS encryption."
   value       = aws_msk_cluster.this.bootstrap_brokers_tls
+  sensitive   = true
 }
 
 output "msk_cluster_zookeeper_connect_string" {
   description = "A comma separated list of one or more Zookeeper IP addresses and client ports that you can use to connect to the Zookeeper cluster."
   value       = aws_msk_cluster.this.zookeeper_connect_string
+  sensitive   = true
 }

--- a/terraform/modules/network/clientvpn/outputs.tf
+++ b/terraform/modules/network/clientvpn/outputs.tf
@@ -11,6 +11,7 @@ output "client_vpn_endpoint_arn" {
 output "client_vpn_endpoint_dns_name" {
   description = "DNS name of the Client VPN endpoint"
   value       = aws_ec2_client_vpn_endpoint.this.dns_name
+  sensitive   = true
 }
 
 output "security_group_id" {

--- a/terraform/modules/network/vpc-endpoints/main.tf
+++ b/terraform/modules/network/vpc-endpoints/main.tf
@@ -1,0 +1,19 @@
+resource "aws_vpc_endpoint" "this" {
+  for_each = { for svc in var.services : svc.name => svc }
+
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${var.region}.${each.value.name}"
+  vpc_endpoint_type   = each.value.type
+
+  route_table_ids     = each.value.type == "Gateway" ? var.route_table_ids : null
+  subnet_ids          = each.value.type == "Interface" ? var.subnet_ids : null
+  security_group_ids  = each.value.type == "Interface" ? var.security_group_ids : null
+  private_dns_enabled = each.value.type == "Interface" ? each.value.private_dns_enabled : null
+
+  tags = merge(
+    var.common_tags,
+    {
+      Name = "${each.value.name}-vpc-endpoint"
+    }
+  )
+}

--- a/terraform/modules/network/vpc-endpoints/outputs.tf
+++ b/terraform/modules/network/vpc-endpoints/outputs.tf
@@ -1,0 +1,3 @@
+output "vpc_endpoints" {
+  value = aws_vpc_endpoint.this
+}

--- a/terraform/modules/network/vpc-endpoints/variables.tf
+++ b/terraform/modules/network/vpc-endpoints/variables.tf
@@ -1,0 +1,34 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "route_table_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "subnet_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "security_group_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "services" {
+  type = list(object({
+    name                = string   # 예: "dynamodb", "s3", "ssm"
+    type                = string   # "Gateway" or "Interface"
+    private_dns_enabled = optional(bool)
+  }))
+}
+variable "common_tags" {
+  type    = map(string)
+  default = {}
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,6 +4,7 @@
 output "aurora_cluster_endpoints" {
   description = "서비스별 Aurora DB 클러스터의 엔드포인트 주소 맵"
   value       = module.aurora_dbs.aurora_cluster_endpoints
+  sensitive   = true
 }
 
 output "aurora_cluster_ports" {
@@ -137,6 +138,7 @@ output "elasticache_auth_cluster_id" {
 output "elasticache_auth_cluster_endpoint" {
   description = "The endpoint of the ElastiCache cluster for authentication"
   value       = module.elasticache_auth.elasticache_cluster_endpoint
+  sensitive   = true
 }
 
 output "elasticache_recommend_cluster_id" {
@@ -147,6 +149,7 @@ output "elasticache_recommend_cluster_id" {
 output "elasticache_recommend_cluster_endpoint" {
   description = "The endpoint of the ElastiCache cluster for recommendation"
   value       = module.elasticache_recommend.elasticache_cluster_endpoint
+  sensitive   = true
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## ✅ 요약
s3,dynamoDB vpc endpoint설정, output sensitive 설정

## 🧩 변경 내용
- vpc-endpoints 모듈을 추가했습니다. vpc 밖에서 관리되는 s3,dynamoDB에 대한 엔드포인트를 추가하여 네트워킹 속도 향상과 인터넷 게이트웨이/ NAT 게이트웨이 비용을 절감합니다.  인터넷 노출 없이 안전하게 통신이 가능합니다.
- 테라폼 output 코드 중 민감한 정보들에 sensitive = true 설정을 추가했습니다.

