### PR TITLE
fix: argocd 수정, review전용 elasticache 클러스터추가,config server 연동 설정수정

### DIFF
--- a/argocd/service-review/review.yaml
+++ b/argocd/service-review/review.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: review-service-account
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::061039804626:role/review-service-role
+    eks.amazonaws.com/role-arn: arn:aws:iam::061039804626:role/mapzip-dev-review-service-role
 ---
 apiVersion: v1
 kind: Service
@@ -90,7 +90,9 @@ spec:
         - name: MSK_BOOTSTRAP_SERVERS
           value: "mapzip-dev-main-msk.c5.kafka.ap-northeast-2.amazonaws.com:9092"
         - name: ELASTICACHE_ENDPOINT
-          value: "mapzip-dev-auth-cache.hwl2ad.cache.amazonaws.com"
+          value: "mapzip-dev-review-cache.xxxxx.cache.amazonaws.com"
+        - name: CLOUDFRONT_IMAGE_DOMAIN
+          value: "https://img.mapzip.shop"
         - name: GOOGLE_CLOUD_VISION_API_KEY
           valueFrom:
             secretKeyRef:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -357,6 +357,18 @@ module "elasticache_recommend" {
   node_type                     = "cache.t3.medium" # 추천용은 중간 사양
 }
 
+# 리뷰 서버 전용 ElastiCache
+module "elasticache_review" {
+  source                        = "./modules/elasticache"
+  name_prefix                   = local.common_prefix
+  environment                   = terraform.workspace
+  cluster_name                  = "review-cache"
+  common_tags                   = local.common_tags
+  elasticache_subnet_group_name = aws_elasticache_subnet_group.main.name
+  security_group_ids            = [aws_security_group.elasticache_sg.id]
+  node_type                     = "cache.t3.small" # 리뷰용은 작은 사양
+}
+
 resource "aws_elasticache_subnet_group" "main" {
   name        = "${local.common_prefix}elasticache-subnet-group"
   subnet_ids  = module.private_subnets.subnet_ids

--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -14,18 +14,24 @@ resource "aws_cloudfront_distribution" "this" {
   default_root_object = "index.html"
 
   default_cache_behavior {
-    allowed_methods  = ["GET", "HEAD"]
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "S3-${var.bucket_domain_name}"
 
     viewer_protocol_policy = "redirect-to-https"
 
     forwarded_values {
-      query_string = false
+      query_string = true  # S3 업로드 시 query string 필요
+      headers      = ["Authorization", "Content-Type", "Content-MD5", "x-amz-*"]  # S3 업로드 헤더 전달
       cookies {
         forward = "none"
       }
     }
+
+    # 업로드 요청은 캐싱하지 않음
+    min_ttl                = 0
+    default_ttl            = 86400   # 1일 (GET 요청용)
+    max_ttl                = 31536000 # 1년
   }
 
   viewer_certificate {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -149,6 +149,16 @@ output "elasticache_recommend_cluster_endpoint" {
   value       = module.elasticache_recommend.elasticache_cluster_endpoint
 }
 
+output "elasticache_review_cluster_id" {
+  description = "The ID of the ElastiCache cluster for review"
+  value       = module.elasticache_review.elasticache_cluster_id
+}
+
+output "elasticache_review_cluster_endpoint" {
+  description = "The endpoint of the ElastiCache cluster for review"
+  value       = module.elasticache_review.elasticache_cluster_endpoint
+}
+
 # ------------------------------------------------------------------------------
 # EKS 관련 정보 출력
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## ✅ 요약
ArgoCD Review 서비스 설정 개선
리뷰서버 인프라 개선 (main.tf, outputs.tf)

## 🧩 변경 내용
  1. argocd/service-review/review.yaml:
    - MSK_BOOTSTRAP_SERVERS 중복 제거
    - ElastiCache 엔드포인트 수정
  2. terraform/main.tf:
    - Review 전용 ElastiCache 클러스터 추가
  3. terraform/outputs.tf:
    - Review ElastiCache 출력값 추가
  4. terraform/modules/cloudfront/main.tf:
    - CloudFront 관련 수정

## 🔍 확인 필요사항 (선택)
실제 ElastiCache 엔드포인트로 review.yaml 업데이트
Google Vision API 키 등록

## 📝 메모 
내가 기억하고 싶은 내용, 후속 작업 아이디어 등
