### PR TITLE
fix: GitHub Actions EKS 접근 권한 추가

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -288,6 +288,7 @@ module "eks" {
   cluster_name        = "mapzip-${terraform.workspace}-eks"
   cluster_role_arn    = module.iam.eks_cluster_role_arn
   node_group_role_arn = module.iam.eks_node_group_role_arn
+  github_actions_role_arn = module.github_oidc_role.role_arn
   subnet_ids          = module.private_subnets.subnet_ids
   vpc_id              = module.vpc.vpc_id
   public_access_cidrs = ["0.0.0.0/0"]

--- a/terraform/modules/eks/aws-auth.tf
+++ b/terraform/modules/eks/aws-auth.tf
@@ -1,0 +1,36 @@
+# aws-auth ConfigMap 관리
+# GitHub Actions OIDC 역할을 EKS 클러스터에 추가
+
+resource "kubernetes_config_map_v1" "aws_auth" {
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+
+  data = {
+    mapRoles = yamlencode([
+      # EKS Node Group 역할 (기본)
+      {
+        rolearn  = var.node_group_role_arn
+        username = "system:node:{{EC2PrivateDNSName}}"
+        groups = [
+          "system:bootstrappers",
+          "system:nodes"
+        ]
+      },
+      # GitHub Actions OIDC 역할 추가
+      {
+        rolearn  = var.github_actions_role_arn
+        username = "github-actions"
+        groups = [
+          "system:masters"
+        ]
+      }
+    ])
+  }
+
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_eks_node_group.this
+  ]
+}

--- a/terraform/modules/eks/variables.tf
+++ b/terraform/modules/eks/variables.tf
@@ -43,3 +43,8 @@ variable "aws_region" {
   type        = string
   default     = "ap-northeast-2"
 }
+
+variable "github_actions_role_arn" {
+  description = "ARN of the GitHub Actions OIDC role for EKS access"
+  type        = string
+}


### PR DESCRIPTION
## 🚨 문제상황
GitHub Actions CI/CD 워크플로우에서 EKS 클러스터의 서비스 재시작 시 권한 오류 발생

**에러**: `Restart gateway service` 단계에서 실패
- 참조: https://github.com/CLD3rd-Team4/App/actions/runs/16743782315/job/47397463042

## 🔧 해결방법
GitHub Actions OIDC 역할을 EKS `aws-auth` ConfigMap에 `system:masters` 권한으로 추가

## ✅ 변경사항
- **aws-auth.tf**: Terraform으로 EKS 인증 관리
- **variables.tf**: `github_actions_role_arn` 변수 추가  
- **main.tf**: EKS 모듈에 GitHub Actions 역할 ARN 전달

## 🎯 결과
- ✅ GitHub Actions에서 `kubectl` 명령어 실행 가능
- ✅ 서비스 재시작 워크플로우 정상 작동
- ✅ Infrastructure as Code 방식 (수동 kubectl 패치 불필요)

## 🧪 테스트 방법
머지 및 apply 후:
1. 실패한 GitHub Actions 워크플로우 재실행
2. 서비스 재시작 성공 확인
3. EKS 접근 권한 정상 작동 확인