### PR TITLE
fix:보안그룹 수시변경 방지,커스텀에러설정 주석

### DIFF
--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -35,14 +35,14 @@ resource "aws_cloudfront_distribution" "this" {
     //max_ttl                = 31536000 # 1년
   }
 
-  dynamic "custom_error_response" {
-    for_each = var.is_website ? [403, 404] : []
-    content {
-      error_code         = custom_error_response.value
-      response_code      = 200
-      response_page_path = "/index.html"
-    }
-  }
+  # dynamic "custom_error_response" {
+  #   for_each = var.is_website ? [403, 404] : []
+  #   content {
+  #     error_code         = custom_error_response.value
+  #     response_code      = 200
+  #     response_page_path = "/index.html"
+  #   }
+  # }
 
   viewer_certificate {
     acm_certificate_arn            = var.acm_certificate_arn

--- a/terraform/modules/eks/security_group.tf
+++ b/terraform/modules/eks/security_group.tf
@@ -108,5 +108,11 @@ resource "aws_security_group" "aws_eks_node_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  lifecycle {
+    ignore_changes = [
+      ingress  # 인바운드 규칙 변경 감시 무시
+    ]
+  }
+
   tags = var.common_tags
 }


### PR DESCRIPTION
## ✅ 요약
보안그룹 수시변경 방지,커스텀에러설정 주석
보안그룹이 수시로 변경되어 alb controller의 보안그룹이 설정이 삭제되어 헬스체크가 실패합니다. 이를 수정했습니다.
cloudfront 커스텀 에러설정은 디버깅을 위해 주석처리했습니다.
