### PR TITLE
feat: Add comprehensive DynamoDB and ElastiCache monitoring

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -630,6 +630,11 @@ module "db_alert_sns" {
       slack_channel      = "#1-schedule"
       webhook_url        = var.schedule_webhook_url
     }
+    review = {
+      cluster_identifier = "mapzip-dev-reviews-table"
+      slack_channel      = "#1-review"
+      webhook_url        = var.review_webhook_url
+    }
   }
 }
 
@@ -654,6 +659,11 @@ module "db_alert_lambda" {
       cluster_identifier = "mapzip-dev-schedule-db"
       slack_channel      = "#1-schedule"
       webhook_url        = var.schedule_webhook_url
+    }
+    review = {
+      cluster_identifier = "mapzip-dev-reviews-table"
+      slack_channel      = "#1-review"
+      webhook_url        = var.review_webhook_url
     }
   }
   sns_topic_arns = module.db_alert_sns.sns_topic_arns
@@ -681,12 +691,48 @@ module "db_alert_cloudwatch" {
       slack_channel      = "#1-schedule"
       webhook_url        = var.schedule_webhook_url
     }
+    review = {
+      cluster_identifier = "mapzip-dev-reviews-table"
+      slack_channel      = "#1-review"
+      webhook_url        = var.review_webhook_url
+    }
   }
+  
+  # DynamoDB 테이블 모니터링
+  dynamodb_tables = {
+    review = {
+      table_name = "mapzip-dev-reviews"
+    }
+  }
+  
+  # ElastiCache 클러스터 모니터링
+  elasticache_clusters = {
+    auth = {
+      cluster_id = "mapzip-dev-auth-cache"
+    }
+    recommend = {
+      cluster_id = "mapzip-dev-recommend-cache"
+    }
+    review = {
+      cluster_id = "mapzip-dev-review-cache"
+    }
+  }
+
   sns_topic_arns = module.db_alert_sns.sns_topic_arns
 
-  # 임계값 설정
+  # 기존 RDS 임계값 설정
   cpu_threshold           = 80          # 80%
   memory_threshold        = 1073741824  # 1GB
   read_latency_threshold  = 0.1         # 100ms
   write_latency_threshold = 0.1         # 100ms
+  
+  # 새로운 DynamoDB 임계값 설정
+  dynamodb_throttle_threshold = 5       # 5회
+  dynamodb_error_threshold    = 10      # 10회
+  
+  # 새로운 ElastiCache 임계값 설정
+  elasticache_cpu_threshold         = 80   # 80%
+  elasticache_memory_threshold      = 80   # 80%
+  elasticache_connections_threshold = 100  # 100개
+  elasticache_hit_rate_threshold    = 80   # 80%
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -707,7 +707,7 @@ module "db_alert_cloudwatch" {
   
   # ElastiCache 클러스터 모니터링
   elasticache_clusters = {
-    auth = {
+    oauth = {
       cluster_id = "mapzip-dev-auth-cache"
     }
     recommend = {

--- a/terraform/modules/cloudwatch/main.tf
+++ b/terraform/modules/cloudwatch/main.tf
@@ -101,3 +101,219 @@ resource "aws_cloudwatch_metric_alarm" "db_write_latency_high" {
     Service = each.key
   })
 }
+
+# =============================================================================
+# DynamoDB 모니터링 알람
+# =============================================================================
+
+# DynamoDB 읽기 스로틀 알람
+resource "aws_cloudwatch_metric_alarm" "dynamodb_read_throttled_requests" {
+  for_each = var.dynamodb_tables
+
+  alarm_name          = "${var.common_prefix}${each.key}-dynamodb-read-throttled"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "ReadThrottledRequests"
+  namespace           = "AWS/DynamoDB"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = var.dynamodb_throttle_threshold
+  alarm_description   = "This metric monitors ${each.key} DynamoDB read throttling"
+  alarm_actions       = [var.sns_topic_arns[each.key]]
+  ok_actions          = [var.sns_topic_arns[each.key]]
+
+  dimensions = {
+    TableName = each.value.table_name
+  }
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.common_prefix}${each.key}-dynamodb-read-throttled"
+    Service = each.key
+  })
+}
+
+# DynamoDB 쓰기 스로틀 알람
+resource "aws_cloudwatch_metric_alarm" "dynamodb_write_throttled_requests" {
+  for_each = var.dynamodb_tables
+
+  alarm_name          = "${var.common_prefix}${each.key}-dynamodb-write-throttled"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "WriteThrottledRequests"
+  namespace           = "AWS/DynamoDB"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = var.dynamodb_throttle_threshold
+  alarm_description   = "This metric monitors ${each.key} DynamoDB write throttling"
+  alarm_actions       = [var.sns_topic_arns[each.key]]
+  ok_actions          = [var.sns_topic_arns[each.key]]
+
+  dimensions = {
+    TableName = each.value.table_name
+  }
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.common_prefix}${each.key}-dynamodb-write-throttled"
+    Service = each.key
+  })
+}
+
+# DynamoDB 시스템 에러 알람
+resource "aws_cloudwatch_metric_alarm" "dynamodb_system_errors" {
+  for_each = var.dynamodb_tables
+
+  alarm_name          = "${var.common_prefix}${each.key}-dynamodb-system-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "SystemErrors"
+  namespace           = "AWS/DynamoDB"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = var.dynamodb_error_threshold
+  alarm_description   = "This metric monitors ${each.key} DynamoDB system errors"
+  alarm_actions       = [var.sns_topic_arns[each.key]]
+  ok_actions          = [var.sns_topic_arns[each.key]]
+
+  dimensions = {
+    TableName = each.value.table_name
+  }
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.common_prefix}${each.key}-dynamodb-system-errors"
+    Service = each.key
+  })
+}
+
+# DynamoDB 사용자 에러 알람
+resource "aws_cloudwatch_metric_alarm" "dynamodb_user_errors" {
+  for_each = var.dynamodb_tables
+
+  alarm_name          = "${var.common_prefix}${each.key}-dynamodb-user-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "UserErrors"
+  namespace           = "AWS/DynamoDB"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = var.dynamodb_error_threshold
+  alarm_description   = "This metric monitors ${each.key} DynamoDB user errors"
+  alarm_actions       = [var.sns_topic_arns[each.key]]
+  ok_actions          = [var.sns_topic_arns[each.key]]
+
+  dimensions = {
+    TableName = each.value.table_name
+  }
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.common_prefix}${each.key}-dynamodb-user-errors"
+    Service = each.key
+  })
+}
+
+# =============================================================================
+# ElastiCache 모니터링 알람
+# =============================================================================
+
+# ElastiCache CPU 사용률 알람
+resource "aws_cloudwatch_metric_alarm" "elasticache_cpu_high" {
+  for_each = var.elasticache_clusters
+
+  alarm_name          = "${var.common_prefix}${each.key}-elasticache-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ElastiCache"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.elasticache_cpu_threshold
+  alarm_description   = "This metric monitors ${each.key} ElastiCache CPU utilization"
+  alarm_actions       = [var.sns_topic_arns[each.key]]
+  ok_actions          = [var.sns_topic_arns[each.key]]
+
+  dimensions = {
+    CacheClusterId = each.value.cluster_id
+  }
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.common_prefix}${each.key}-elasticache-cpu-high"
+    Service = each.key
+  })
+}
+
+# ElastiCache 메모리 사용률 알람
+resource "aws_cloudwatch_metric_alarm" "elasticache_memory_high" {
+  for_each = var.elasticache_clusters
+
+  alarm_name          = "${var.common_prefix}${each.key}-elasticache-memory-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.elasticache_memory_threshold
+  alarm_description   = "This metric monitors ${each.key} ElastiCache memory usage"
+  alarm_actions       = [var.sns_topic_arns[each.key]]
+  ok_actions          = [var.sns_topic_arns[each.key]]
+
+  dimensions = {
+    CacheClusterId = each.value.cluster_id
+  }
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.common_prefix}${each.key}-elasticache-memory-high"
+    Service = each.key
+  })
+}
+
+# ElastiCache 연결 수 알람
+resource "aws_cloudwatch_metric_alarm" "elasticache_connections_high" {
+  for_each = var.elasticache_clusters
+
+  alarm_name          = "${var.common_prefix}${each.key}-elasticache-connections-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CurrConnections"
+  namespace           = "AWS/ElastiCache"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.elasticache_connections_threshold
+  alarm_description   = "This metric monitors ${each.key} ElastiCache current connections"
+  alarm_actions       = [var.sns_topic_arns[each.key]]
+  ok_actions          = [var.sns_topic_arns[each.key]]
+
+  dimensions = {
+    CacheClusterId = each.value.cluster_id
+  }
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.common_prefix}${each.key}-elasticache-connections-high"
+    Service = each.key
+  })
+}
+
+# ElastiCache 캐시 히트율 알람 (낮을 때)
+resource "aws_cloudwatch_metric_alarm" "elasticache_cache_hit_rate_low" {
+  for_each = var.elasticache_clusters
+
+  alarm_name          = "${var.common_prefix}${each.key}-elasticache-cache-hit-rate-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CacheHitRate"
+  namespace           = "AWS/ElastiCache"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.elasticache_hit_rate_threshold
+  alarm_description   = "This metric monitors ${each.key} ElastiCache cache hit rate"
+  alarm_actions       = [var.sns_topic_arns[each.key]]
+  ok_actions          = [var.sns_topic_arns[each.key]]
+
+  dimensions = {
+    CacheClusterId = each.value.cluster_id
+  }
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.common_prefix}${each.key}-elasticache-cache-hit-rate-low"
+    Service = each.key
+  })
+}

--- a/terraform/modules/cloudwatch/variables.tf
+++ b/terraform/modules/cloudwatch/variables.tf
@@ -46,3 +46,63 @@ variable "write_latency_threshold" {
   type        = number
   default     = 0.1
 }
+
+# =============================================================================
+# DynamoDB 모니터링 변수
+# =============================================================================
+
+variable "dynamodb_tables" {
+  description = "Map of DynamoDB tables with their configurations"
+  type = map(object({
+    table_name = string
+  }))
+  default = {}
+}
+
+variable "dynamodb_throttle_threshold" {
+  description = "DynamoDB throttle requests threshold (count)"
+  type        = number
+  default     = 5
+}
+
+variable "dynamodb_error_threshold" {
+  description = "DynamoDB error threshold (count)"
+  type        = number
+  default     = 10
+}
+
+# =============================================================================
+# ElastiCache 모니터링 변수
+# =============================================================================
+
+variable "elasticache_clusters" {
+  description = "Map of ElastiCache clusters with their configurations"
+  type = map(object({
+    cluster_id = string
+  }))
+  default = {}
+}
+
+variable "elasticache_cpu_threshold" {
+  description = "ElastiCache CPU utilization threshold (percentage)"
+  type        = number
+  default     = 80
+}
+
+variable "elasticache_memory_threshold" {
+  description = "ElastiCache memory usage threshold (percentage)"
+  type        = number
+  default     = 80
+}
+
+variable "elasticache_connections_threshold" {
+  description = "ElastiCache current connections threshold (count)"
+  type        = number
+  default     = 100
+}
+
+variable "elasticache_hit_rate_threshold" {
+  description = "ElastiCache cache hit rate threshold (percentage)"
+  type        = number
+  default     = 80
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -163,3 +163,9 @@ variable "schedule_webhook_url" {
   type        = string
   sensitive   = true
 }
+
+variable "review_webhook_url" {
+  description = "Slack webhook URL for review service alerts"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## 🎯 **DynamoDB & ElastiCache 모니터링 추가**

### 📊 **새로 추가된 모니터링**

#### 🗄️ **DynamoDB 모니터링 (Review 서비스)**
- **테이블**: `mapzip-dev-reviews`
- **메트릭**:
  - ReadThrottledRequests / WriteThrottledRequests (임계값: 5회)
  - SystemErrors / UserErrors (임계값: 10회)
- **알림**: `#1-review` Slack 채널

#### 🔄 **ElastiCache 모니터링 (전체 서비스)**
- **클러스터들**:
  - `mapzip-dev-auth-cache` → `#1-platform`
  - `mapzip-dev-recommend-cache` → `#1-recommend`  
  - `mapzip-dev-review-cache` → `#1-review`
- **메트릭**:
  - CPU 사용률 (임계값: 80%)
  - 메모리 사용률 (임계값: 80%)
  - 연결 수 (임계값: 100개)
  - 캐시 히트율 (임계값: 80% 미만)

### 🔧 **인프라 변경사항**

#### ✅ **추가된 구성요소**
- `review_webhook_url` 변수 추가
- CloudWatch 모듈에 DynamoDB/ElastiCache 지원 확장
- SNS, Lambda, CloudWatch 모듈에 Review 서비스 추가
- 모든 데이터베이스 타입에 대한 포괄적 모니터링

#### 📬 **알림 매핑**
```
┌─────────────────┬──────────────────┬─────────────────┐
│   서비스명      │   데이터베이스   │   Slack 채널    │
├─────────────────┼──────────────────┼─────────────────┤
│ Auth 서비스     │ RDS + ElastiCache│ #1-platform     │
│ Recommend 서비스│ RDS + ElastiCache│ #1-recommend    │
│ Schedule 서비스 │ RDS              │ #1-schedule     │
│ Review 서비스   │ DynamoDB + ElastiCache│ #1-review  │
└─────────────────┴──────────────────┴─────────────────┘
```
