### PR TITLE
infra:캐시,DB 장애대응 설정 및 서버리스 valkey 추가

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -24,6 +24,25 @@ provider "registry.terraform.io/cyrilgdn/postgresql" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:RzToQiFwVaxcV0QmgbyaKgNOhqc6oLKiFyZTrQSGcog=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.4.0"
   constraints = "~> 6.4.0"
@@ -45,6 +64,25 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:b763c7c1bf5d8077d6499fd270cad249a712dd9522c6a6e4de49b278280806c5",
     "zh:db69df59bef6f9d8bcb164414b4efa52c0c531c346d6b8b232917afa9b1c4a96",
     "zh:dd9f98f64530386b8faaf9c55ec4b08e58725788c38683272a34684d82f866f7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.4"
+  hashes = [
+    "h1:+Ag4hSb4qQjNtAS6gj2+gsGl7v0iB/Bif6zZZU8lXsw=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
   ]
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -365,9 +365,11 @@ module "elasticache_auth" {
   environment                   = terraform.workspace
   cluster_name                  = "auth-cache"
   common_tags                   = local.common_tags
+  snapshot_retention_limit      = var.snapshot_retention_limit
   elasticache_subnet_group_name = aws_elasticache_subnet_group.main.name
   security_group_ids            = [aws_security_group.elasticache_sg.id]
   node_type                     = "cache.t3.small" # 인증용은 작은 사양
+  num_cache_nodes               = var.valkey_num_cache_nodes
 }
 
 module "elasticache_recommend" {
@@ -376,9 +378,11 @@ module "elasticache_recommend" {
   environment                   = terraform.workspace
   cluster_name                  = "recommend-cache"
   common_tags                   = local.common_tags
+  snapshot_retention_limit      = var.snapshot_retention_limit
   elasticache_subnet_group_name = aws_elasticache_subnet_group.main.name
   security_group_ids            = [aws_security_group.elasticache_sg.id]
   node_type                     = "cache.t3.medium" # 추천용은 중간 사양
+  num_cache_nodes               = var.valkey_num_cache_nodes
 }
 
 # 리뷰 서버 전용 ElastiCache
@@ -388,9 +392,24 @@ module "elasticache_review" {
   environment                   = terraform.workspace
   cluster_name                  = "review-cache"
   common_tags                   = local.common_tags
+  snapshot_retention_limit      = var.snapshot_retention_limit
   elasticache_subnet_group_name = aws_elasticache_subnet_group.main.name
   security_group_ids            = [aws_security_group.elasticache_sg.id]
   node_type                     = "cache.t3.small" # 리뷰용은 작은 사양
+  num_cache_nodes               = var.valkey_num_cache_nodes
+}
+
+module "elasticache_serverless_schedule" {
+  source                        = "./modules/elasticache"
+  use_serverless_cache          = true
+  name_prefix                   = local.common_prefix
+  environment                   = terraform.workspace
+  cluster_name                  = "schedule-cache"
+  common_tags                   = local.common_tags
+  snapshot_retention_limit      = var.snapshot_retention_limit
+  security_group_ids            = [aws_security_group.elasticache_sg.id]
+  subnet_ids                    = module.private_subnets.subnet_ids
+  serverless_cache_data_storage_maximum = var.serverless_cache_data_storage_maximum
 }
 
 resource "aws_elasticache_subnet_group" "main" {

--- a/terraform/modules/dynamodb/main.tf
+++ b/terraform/modules/dynamodb/main.tf
@@ -56,4 +56,8 @@ resource "aws_dynamodb_table" "this" {
       Name = "${var.name_prefix}-${var.table_name}"
     }
   )
+
+  point_in_time_recovery {
+    enabled = terraform.workspace == "prod" ? true : false
+  }
 }

--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -1,9 +1,14 @@
 
 output "elasticache_cluster_id" {
-  value = aws_elasticache_replication_group.this.replication_group_id
+  value = length(aws_elasticache_replication_group.this) > 0 ?aws_elasticache_replication_group.this[0].replication_group_id : null
 }
 
 output "elasticache_cluster_endpoint" {
-  value = aws_elasticache_replication_group.this.configuration_endpoint_address != null ? aws_elasticache_replication_group.this.configuration_endpoint_address : aws_elasticache_replication_group.this.primary_endpoint_address
+  value = length(aws_elasticache_replication_group.this) > 0 ?(aws_elasticache_replication_group.this[0].configuration_endpoint_address != null ? aws_elasticache_replication_group.this[0].configuration_endpoint_address : aws_elasticache_replication_group.this[0].primary_endpoint_address) : null
+  sensitive = true
+}
+
+output "valkey_serverless_endpoint" {
+  value     = length(aws_elasticache_serverless_cache.this) > 0 ?aws_elasticache_serverless_cache.this[0].endpoint : null
   sensitive = true
 }

--- a/terraform/modules/elasticache/variables.tf
+++ b/terraform/modules/elasticache/variables.tf
@@ -16,6 +16,12 @@ variable "cluster_name" {
 variable "elasticache_subnet_group_name" {
   description = "Subnet group name for ElastiCache"
   type        = string
+  default     = ""
+}
+
+variable "snapshot_retention_limit" {
+  description = "The number of days to retain snapshots"
+  type        = number
 }
 
 variable "security_group_ids" {
@@ -45,4 +51,22 @@ variable "parameter_group_name" {
   description = "The parameter group for the ElastiCache cluster"
   type        = string
   default     = "default.valkey8"
+}
+
+variable "use_serverless_cache" {
+  description = "Whether to create a serverless cache"
+  type        = bool
+  default     = false
+}
+
+variable "serverless_cache_data_storage_maximum" {
+  description = "Maximum data storage for the serverless cache in GB"
+  type        = number
+  default     = 10
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for the ElastiCache serverless cache"
+  type        = list(string)
+  default     = []  
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,7 +19,11 @@ variable "aws_region" {
   default     = "ap-northeast-2"
 }
 
-
+variable "valkey_num_cache_nodes" {
+  description = "ElastiCache 클러스터의 캐시 노드 개수"
+  type        = number
+  default     = 1
+}
 
 variable "db_master_username" {
   description = "데이터베이스 마스터 사용자 이름"
@@ -162,4 +166,17 @@ variable "schedule_webhook_url" {
   description = "Slack webhook URL for schedule DB alerts"
   type        = string
   sensitive   = true
+}
+
+
+variable "serverless_cache_data_storage_maximum" {
+  description = "Maximum storage size for serverless cache data in GB"
+  type        = number
+  default     = 10
+}
+
+variable "snapshot_retention_limit" {
+  description = "Number of days to retain snapshots for ElastiCache"
+  type        = number
+  default     = 1
 }


### PR DESCRIPTION
## ✅ 요약
캐시,DB 장애대응 설정 및 서버리스 valkey 추가

## 🧩 변경 내용
- 장애대응을 위해 prod환경에서 dynamoDB PITR설정 추가, 엘라스티캐시 스냅샷 설정을 추가했습니다.
- 서버리스 valkey를 추가하여 스케줄서버에서 사용 가능하도록 설정했습니다.

## 🔍 확인 필요사항 (선택)
스케줄 서버에서 서버리스 valkey 연결이 제대로 되는지 확인 필요