### PR TITLE
fix: 리뷰서버 환경변수, DynamoDB 테이블명 변경

### DIFF
--- a/argocd/service-review/review.yaml
+++ b/argocd/service-review/review.yaml
@@ -103,8 +103,10 @@ spec:
           value: "mapzip-dev-image"
         - name: MSK_BOOTSTRAP_SERVERS
           value: "mapzip-dev-main-msk.c5.kafka.ap-northeast-2.amazonaws.com:9092"
-        - name: ELASTICACHE_ENDPOINT
-          value: "mapzip-dev-review-cache.xxxxx.cache.amazonaws.com"
+        - name: REDIS_HOST
+          value: "mapzip-dev-review-cache.cache.amazonaws.com"
+        - name: REDIS_PORT
+          value: "6379"
         - name: CLOUDFRONT_IMAGE_DOMAIN
           value: "https://img.mapzip.shop"
         - name: GOOGLE_CLOUD_VISION_API_KEY

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -355,7 +355,7 @@ module "dynamodb" {
   source       = "./modules/dynamodb"
   name_prefix  = local.common_prefix
   environment  = terraform.workspace
-  table_name   = "reviews"
+  table_name   = "review"
   common_tags  = local.common_tags
 }
 


### PR DESCRIPTION
## ✅ 요약
 1. Review 서비스 Redis 환경변수 변경
 2. DynamoDB 테이블명 변경
## 🧩 변경 내용
- DynamoDB 모듈의 table_name: "reviews" → "review"
- ELASTICACHE_ENDPOINT → REDIS_HOST/REDIS_PORT로 분리
- 엔드포인트 URL 수정: mapzip-dev-review-cache.cache.amazonaws.com
- 
## 🔍 확인 필요사항 (선택)
- Review 서비스의 Redis 연결 정상 동작 확인
- DynamoDB 테이블명 변경에 따른 애플리케이션 코드 호환성 점검

