### PR TITLE
fix: SNS 메시지 구조 분석 결과 반영하여 Lambda 함수 수정

### DIFF
--- a/terraform/modules/lambda/slack_notifier.py
+++ b/terraform/modules/lambda/slack_notifier.py
@@ -27,16 +27,16 @@ def lambda_handler(event, context):
     
     print(f"DEBUG: Basic alarm info - Name: {alarm_name}, State: {new_state}, Time: {timestamp}")
     
-    # 메트릭 정보 추출
-    metric_name = sns_message.get('MetricName', 'Unknown')
-    namespace = sns_message.get('Namespace', 'Unknown')
-    threshold = sns_message.get('Threshold', 'Unknown')
-    
-    print(f"DEBUG: Metric info - Name: {metric_name}, Namespace: {namespace}, Threshold: {threshold}")
-    
-    # Trigger 정보에서 실제 값 추출
+    # Trigger 정보에서 메트릭 정보 추출
     trigger = sns_message.get('Trigger', {})
     print(f"DEBUG: Trigger info: {json.dumps(trigger, indent=2)}")
+    
+    # 메트릭 정보는 Trigger 객체 안에 있음
+    metric_name = trigger.get('MetricName', 'Unknown')
+    namespace = trigger.get('Namespace', 'Unknown')
+    threshold = trigger.get('Threshold', 'Unknown')
+    
+    print(f"DEBUG: Metric info - Name: {metric_name}, Namespace: {namespace}, Threshold: {threshold}")
     
     dimensions = trigger.get('Dimensions', [])
     print(f"DEBUG: Dimensions: {json.dumps(dimensions, indent=2)}")
@@ -67,8 +67,10 @@ def lambda_handler(event, context):
     kst_time = 'Unknown'
     try:
         print(f"DEBUG: Converting timestamp: {timestamp}")
-        # ISO 형식의 UTC 시간을 파싱
-        utc_dt = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+        # ISO 형식의 UTC 시간을 파싱 (+0000을 +00:00으로 변환)
+        timestamp_fixed = timestamp.replace('+0000', '+00:00').replace('Z', '+00:00')
+        print(f"DEBUG: Fixed timestamp format: {timestamp_fixed}")
+        utc_dt = datetime.fromisoformat(timestamp_fixed)
         print(f"DEBUG: Parsed UTC datetime: {utc_dt}")
         # KST는 UTC+9
         kst_dt = utc_dt.astimezone(timezone(timedelta(hours=9)))


### PR DESCRIPTION
## 📋 요약
디버깅 로그 분석 결과를 바탕으로 Lambda 함수의 메트릭 정보 추출 및 시간 변환 문제 수정

## 🔧 수정 사항
### 메트릭 정보 추출 수정
- ✅ **Trigger 객체에서 정보 추출**: MetricName, Namespace, Threshold를 sns_message.Trigger에서 가져오도록 수정
- ✅ **올바른 데이터 소스**: 기존에 최상위 레벨에서 찾던 정보를 올바른 위치에서 추출

### 시간 변환 수정  
- ✅ **ISO 형식 파싱 개선**: +0000 형태를 +00:00으로 변환하여 Python datetime.fromisoformat() 호환
- ✅ **KST 변환 정상화**: 한국 표준시 변환이 정상 작동하도록 수정

## 🐛 해결된 문제점
이전 디버깅에서 발견된 문제들:
- ❌ **임계값 Unknown** → ✅ **정상 표시** (예: 1.0%)
- ❌ **메트릭 Unknown** → ✅ **정상 표시** (예: CPUUtilization | AWS/ElastiCache)  
- ❌ **UTC 시간 표시** → ✅ **KST 변환** (예: 2025-08-07 15:06:05 KST)

## 🧪 디버깅 로그 분석 결과
실제 SNS 메시지 구조:
```json
{
  "AlarmName": "mapzip-dev-oauth-elasticache-cpu-high",
  "StateChangeTime": "2025-08-07T06:06:05.064+0000",
  "Trigger": {
    "MetricName": "CPUUtilization",
    "Namespace": "AWS/ElastiCache", 
    "Threshold": 1.0,
    "Dimensions": [{"name": "CacheClusterId", "value": "mapzip-dev-auth-cache-001"}]
  }
}
```

## 🚀 예상 결과
수정 후 슬랙 메시지:
- 🕐 **시간**: 2025-08-07 15:06:05 KST
- ⚡ **임계값**: 1.0%  
- 💡 **메트릭**: CPUUtilization | AWS/ElastiCache

## 🔄 다음 단계
1. 테라폼 클라우드에서 배포
2. 알람 트리거하여 수정 결과 확인
3. 디버깅 로그 정리 (운영환경에서는 불필요)