### PR TITLE
infra: cname 레코드로 엔드포인트 도메인 설정

### DIFF
--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -9,6 +9,6 @@ output "elasticache_cluster_endpoint" {
 }
 
 output "valkey_serverless_endpoint" {
-  value     = length(aws_elasticache_serverless_cache.this) > 0 ?aws_elasticache_serverless_cache.this[0].endpoint : null
+  value     = length(aws_elasticache_serverless_cache.this) > 0 ?aws_elasticache_serverless_cache.this[0].endpoint[0].address : null
   sensitive = true
 }

--- a/terraform/modules/record/main.tf
+++ b/terraform/modules/record/main.tf
@@ -20,11 +20,12 @@ resource "aws_route53_record" "txt_record" {
   records = var.records
 }
 
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 6.0"
-    }
-  }
+
+resource "aws_route53_record" "cname_record" {
+  count   = var.record_type == "CNAME" ? 1 : 0
+  zone_id = var.zone_id
+  name    = var.name
+  type    = "CNAME"
+  ttl     = var.ttl
+  records = var.records
 }


### PR DESCRIPTION
## ✅ 요약
cname 레코드들을 추가해 데이터베이스, 엘라스틱캐시, 클라이언트vpn의 엔드포인트를 설정했습니다. 
