### PR TITLE
fix:클라이언트vpn 엔드포인트에 *. 제거

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -199,7 +199,7 @@ module "cname_records" {
   record_type = "CNAME"
   zone_id     = module.route53.zone_id
   name        = each.key
-  records     = [each.value]
+  records     = [each.key == "client-vpn.${var.service_domain}" ? replace(each.value, "*.", "") : each.value]
   ttl         = 300
 }
 


### PR DESCRIPTION
## ✅ 요약
cname 레코드가  클라이언트vpn 엔드포인트에 *. 를 제거한 값을 가르키도록 수정했습니다.
