### PR TITLE
🔧 Fix Recommend Service: Add Missing ServiceAccount

### DIFF
--- a/argocd/service-recommend/recommend.yaml
+++ b/argocd/service-recommend/recommend.yaml
@@ -1,4 +1,11 @@
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: recommend-service-account
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::061039804626:role/mapzip-dev-recommend-service-role
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: recommend


### PR DESCRIPTION
## 🎯 문제 해결
Recommend 서비스 Pod 생성 실패 문제 해결

## 🔍 문제 분석
- **에러**: `serviceaccount "recommend-service-account" not found`
- **원인**: recommend.yaml에 ServiceAccount 정의 누락
- **결과**: Pod 생성 불가, Deployment 0/1 상태

## 📊 비교 분석
### Gateway vs Recommend 차이점:
- **Gateway**: serviceAccountName 미지정 → `default` ServiceAccount 자동 사용 ✅
- **Recommend**: serviceAccountName 명시 → 해당 ServiceAccount 필요 ❌

## 📋 에러 로그 분석 과정
1. `kubectl get pods -n service-recommend` → Pod 없음
2. `kubectl get all -n service-recommend` → Deployment 0/1
3. `kubectl describe replicaset` → **핵심 에러 발견**:
   ```
   Error creating: pods "recommend-deployment-6dddb6c4bc-" is forbidden: 
   error looking up service account service-recommend/recommend-service-account: 
   serviceaccount "recommend-service-account" not found
   ```