### PR TITLE
fix: hpa 임계값 낮추기

### DIFF
--- a/argocd/platform/gateway.yaml
+++ b/argocd/platform/gateway.yaml
@@ -57,14 +57,20 @@ spec:
     kind: Deployment
     name: spring-gateway-deployment
   minReplicas: 1
-  maxReplicas: 3
+  maxReplicas: 5
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 60
+          averageUtilization: 40
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 40
 
 ---
 


### PR DESCRIPTION
## ✅ 요약
gateway 서버의 hpa 임계값을 낮췄습니다. 

## 🧩 변경 내용
- gateway.yaml : hpa의 임계값을 보수적으로 40%로 낮춰 빠르게 스케일아웃 되도록 설정했습니다. 레플리카 수도 5개까지 늘어날 수 있게 설정했습니다.


