### PR TITLE
fix: 메모리 요청량 증가

### DIFF
--- a/argocd/platform/gateway.yaml
+++ b/argocd/platform/gateway.yaml
@@ -107,10 +107,10 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "128Mi"
+            memory: "300Mi"
           limits:
             cpu: "300m"
-            memory: "256Mi"
+            memory: "500Mi"
 
         livenessProbe:
           httpGet:

--- a/scripts/setup-k8s-windows.bat
+++ b/scripts/setup-k8s-windows.bat
@@ -24,7 +24,6 @@ set CLUSTER_NAME=mapzip-dev-eks
 set REGION=ap-northeast-2
 set SERVICE_DOMAIN=mapzip.shop
 set PROMETHEUS_RETENTION=15d
-set TRACING_SAMPLING_PERCENTAGE=100
 
 REM 각자 프로필에 맞게 변경
 set AWS_PROFILE=lt4

--- a/scripts/values/istio-telemetry.yaml
+++ b/scripts/values/istio-telemetry.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: istio-system
 spec:
   tracing:
-  - randomSamplingPercentage: 100
+  - randomSamplingPercentage: 10
     providers:
     - name: jaeger


### PR DESCRIPTION
## ✅ 요약
현재 gateway서버의 메모리 request가 너무 낮아 hpa 스케일다운이 되지 않고있어 조정해줬습니다.

