### PR TITLE
fix: MSK cluster lifecycle and recommend service port fixes

### DIFF
--- a/terraform/modules/msk/main.tf
+++ b/terraform/modules/msk/main.tf
@@ -15,6 +15,14 @@ resource "aws_msk_cluster" "this" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      client_authentication,
+      encryption_info,
+      open_monitoring
+    ]
+  }
+
   tags = merge(
     var.common_tags,
     {


### PR DESCRIPTION
## MSK 클러스터 에러 해결
- MSK 클러스터 불필요한 보안 설정 업데이트 방지
- lifecycle ignore_changes 규칙 추가

## recommend 서비스 포트 수정  
- 포트 불일치 문제 해결: 8080 → 8082
- Service, Container, Health check 포트 통일
- Prometheus 메트릭 포트 수정

**해결되는 문제:**
- Terraform MSK BadRequestException 에러
- recommend 서비스 1/2 Ready 상태 → 2/2 Ready