### PR TITLE
fix: 스케줄,설정서버 프로메테우스 설정 추가

### DIFF
--- a/argocd/platform/config.yaml
+++ b/argocd/platform/config.yaml
@@ -57,6 +57,10 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: spring-config-server
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8888"
+        prometheus.io/path: "/actuator/prometheus"
     spec:
       containers:
       - name: spring-config-server-container

--- a/argocd/service-schedule/schedule.yaml
+++ b/argocd/service-schedule/schedule.yaml
@@ -79,6 +79,9 @@ spec:
       labels:
         app.kubernetes.io/name: schedule
       annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8084"
+        prometheus.io/path: "/actuator/prometheus"
         sidecar.istio.io/userVolume: |
           [
             {


### PR DESCRIPTION
## ✅ 요약
스케줄, 설정서버 프로메테우스 설정 추가

## 🧩 변경 내용
- argocd/platform/config.yaml
- argocd/service-schedule/schedule.yaml

