### PR TITLE
fix: MSK 메시지 크기 제한을 5MB로 증가 및 애플리케이션 Kafka 설정 업데이트

### DIFF
--- a/terraform/modules/msk/main.tf
+++ b/terraform/modules/msk/main.tf
@@ -1,3 +1,21 @@
+# MSK 설정 추가
+resource "aws_msk_configuration" "message_size_config" {
+  kafka_versions = ["2.8.1"]  # 기존 버전 유지
+  name           = "${var.name_prefix}${var.cluster_name}-message-config"
+  description    = "MSK configuration for larger message size"
+
+  server_properties = <<PROPERTIES
+# 메시지 크기 제한을 5MB로 증가
+message.max.bytes=5242880
+replica.fetch.max.bytes=5242880
+
+# 기존 설정 유지 (변경 최소화)
+log.retention.hours=168
+log.segment.bytes=1073741824
+PROPERTIES
+}
+
+# 기존 MSK 클러스터에 설정 적용
 resource "aws_msk_cluster" "this" {
   cluster_name           = "${var.name_prefix}${var.cluster_name}"
   kafka_version          = "2.8.1"
@@ -13,6 +31,12 @@ resource "aws_msk_cluster" "this" {
         volume_size = var.ebs_volume_size
       }
     }
+  }
+
+  # 새 설정 적용
+  configuration_info {
+    arn      = aws_msk_configuration.message_size_config.arn
+    revision = aws_msk_configuration.message_size_config.latest_revision
   }
 
   lifecycle {


### PR DESCRIPTION
## ✅ 요약
Kafka 메시지 크기 제한 오류

## 🧩 변경 내용
- MSK 클러스터 메시지 크기 제한: 1MB → 5MB
- 새로운 MSK 설정 생성 및 기존 클러스터에 적용
- 기존 로그 보존 정책 유지

## 🔍 확인 필요사항 (선택)
적용 시 약 15-20분 소요 예정

## 📝 메모 
내가 기억하고 싶은 내용, 후속 작업 아이디어 등
