### PR TITLE
fix:서버별 리소스 요청량 수정

### DIFF
--- a/argocd/platform/auth.yaml
+++ b/argocd/platform/auth.yaml
@@ -71,11 +71,11 @@ spec:
         
         resources:
           requests:
-            cpu: "200m"
-            memory: "300Mi"
+            cpu: "100m"
+            memory: "600Mi"
           limits:
             cpu: "300m"
-            memory: "500Mi"
+            memory: "800Mi"
 
         livenessProbe:
           httpGet:

--- a/argocd/platform/config.yaml
+++ b/argocd/platform/config.yaml
@@ -90,8 +90,8 @@ spec:
 
         resources:
           requests:
-            cpu: "200m"
-            memory: "256Mi"
+            cpu: "100m"
+            memory: "600Mi"
           limits:
             cpu: "500m"
             memory: "512Mi"

--- a/argocd/platform/gateway.yaml
+++ b/argocd/platform/gateway.yaml
@@ -124,10 +124,10 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "300Mi"
+            memory: "500Mi"
           limits:
             cpu: "300m"
-            memory: "500Mi"
+            memory: "700Mi"
 
         livenessProbe:
           httpGet:

--- a/argocd/service-recommend/recommend.yaml
+++ b/argocd/service-recommend/recommend.yaml
@@ -98,7 +98,7 @@ spec:
               protocol: TCP
           resources:
             requests:
-              cpu: "300m"
+              cpu: "200m"
               memory: "512Mi"
             limits:
               cpu: "800m"

--- a/argocd/service-review/review.yaml
+++ b/argocd/service-review/review.yaml
@@ -126,10 +126,10 @@ spec:
               value: "/var/secrets/google-api.json"
           resources:
             requests:
-              cpu: "200m"
+              cpu: "100m"
               memory: "512Mi"
             limits:
-              cpu: "800m"
+              cpu: "500m"
               memory: "1Gi"
           livenessProbe:
             httpGet:

--- a/scripts/values/argocd-applications.yaml
+++ b/scripts/values/argocd-applications.yaml
@@ -3,6 +3,9 @@ kind: Application
 metadata:
   name: mapzip-dev-service-schedule
   namespace: argocd
+  annotations: 
+    notifications.argoproj.io/subscribe.on-deployed.slack: "#1-schedule"
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: "#1-schedule"
 spec:
   destination:
     namespace: service-schedule
@@ -24,6 +27,9 @@ kind: Application
 metadata:
   name: mapzip-dev-service-recommend
   namespace: argocd
+  annotations: 
+    notifications.argoproj.io/subscribe.on-deployed.slack: "#1-recommend"
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: "#1-recommend"
 spec:
   destination:
     namespace: service-recommend
@@ -45,6 +51,9 @@ kind: Application
 metadata:
   name: mapzip-dev-service-review
   namespace: argocd
+  annotations: 
+    notifications.argoproj.io/subscribe.on-deployed.slack: "#1-review"
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: "#1-review"
 spec:
   destination:
     namespace: service-review
@@ -66,6 +75,9 @@ kind: Application
 metadata:
   name: mapzip-dev-service-platform
   namespace: argocd
+  annotations: 
+    notifications.argoproj.io/subscribe.on-deployed.slack: "#1-platform"
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: "#1-platform"
 spec:
   destination:
     namespace: service-platform
@@ -87,6 +99,9 @@ kind: Application
 metadata:
   name: mapzip-dev-demo
   namespace: argocd
+  annotations: 
+    notifications.argoproj.io/subscribe.on-deployed.slack: "#1-platform"
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: "#1-platform"
 spec:
   destination:
     namespace: demo


### PR DESCRIPTION
## ✅ 요약
서버별 리소스 요청량 수정

## 🧩 변경 내용
- dev 환경에서 각 서버별 cpu사용량은 적은데 현재 요청량 내에서 메모리 사용량이 높아 불필요한 스케일 아웃이 되는 중
- 전체 서버의 메모리 요청량을 소폭 상승하고 cpu 요청량은 감소
- argoCD slack연동을 위해 구독 어노테이션 추가

